### PR TITLE
fix: preserve terminal history when switching panel modes

### DIFF
--- a/src/components/DiffViewer/DiffViewerContext.tsx
+++ b/src/components/DiffViewer/DiffViewerContext.tsx
@@ -8,12 +8,14 @@ const DiffViewerContext = createContext<DiffViewerContextValue | null>(null);
 
 export function DiffViewerProvider({
   gitPolling,
+  enabled = true,
   children,
 }: {
   gitPolling: GitPollingResult;
+  enabled?: boolean;
   children: ReactNode;
 }) {
-  const state = useDiffViewerState(gitPolling);
+  const state = useDiffViewerState(gitPolling, enabled);
   return <DiffViewerContext.Provider value={state}>{children}</DiffViewerContext.Provider>;
 }
 

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -228,63 +228,48 @@ export function MainLayout() {
 
       {/* Main content */}
       <div className="flex-1 overflow-hidden">
-        {/* No panel mode - terminal only */}
-        {panelMode === null ? (
-          <TerminalTabs ref={terminalTabsRef} />
-        ) : panelMode === 'diff' ? (
-          /* Diff mode - 3 panel layout with shared context */
-          <DiffViewerProvider gitPolling={gitPolling}>
-            <PanelGroup direction="horizontal" autoSaveId="main-layout">
-              <Panel defaultSize={40} minSize={20}>
-                <TerminalTabs ref={terminalTabsRef} />
-              </Panel>
+        <DiffViewerProvider gitPolling={gitPolling} enabled={panelMode === 'diff'}>
+          <PanelGroup direction="horizontal" autoSaveId="main-layout">
+            {/* Terminal: ALWAYS mounted, never unmounts */}
+            <Panel id="terminal" order={1} minSize={20}>
+              <TerminalTabs ref={terminalTabsRef} />
+            </Panel>
 
-              <PanelResizeHandle />
-
-              <Panel defaultSize={40} minSize={20}>
+            {/* Diff mode: content + file list */}
+            {panelMode === 'diff' && <PanelResizeHandle />}
+            {panelMode === 'diff' && (
+              <Panel id="diff-content" order={2} defaultSize={40} minSize={20}>
                 <DiffContentPanel />
               </Panel>
-
-              <PanelResizeHandle />
-
-              <Panel defaultSize={20} minSize={10} maxSize={40}>
+            )}
+            {panelMode === 'diff' && <PanelResizeHandle />}
+            {panelMode === 'diff' && (
+              <Panel id="diff-file-list" order={3} defaultSize={20} minSize={10} maxSize={40}>
                 <DiffFileListPanel />
               </Panel>
-            </PanelGroup>
-          </DiffViewerProvider>
-        ) : browseOpenFiles.length === 0 ? (
-          /* Browse mode without file selected - 2 panel layout */
-          <PanelGroup direction="horizontal" autoSaveId="browse-no-file-layout">
-            <Panel defaultSize={60} minSize={20}>
-              <TerminalTabs ref={terminalTabsRef} />
-            </Panel>
+            )}
 
-            <PanelResizeHandle />
-
-            <Panel defaultSize={40} minSize={15}>
-              <BrowseFileListPanel />
-            </Panel>
+            {/* Browse mode: editor (if files open) + file list */}
+            {panelMode === 'browse' && <PanelResizeHandle />}
+            {panelMode === 'browse' && browseOpenFiles.length > 0 && (
+              <Panel id="browse-editor" order={2} defaultSize={40} minSize={20}>
+                <BrowseEditorTabs ref={browseEditorTabsRef} />
+              </Panel>
+            )}
+            {panelMode === 'browse' && browseOpenFiles.length > 0 && <PanelResizeHandle />}
+            {panelMode === 'browse' && (
+              <Panel
+                id="browse-file-list"
+                order={3}
+                defaultSize={browseOpenFiles.length > 0 ? 20 : 40}
+                minSize={browseOpenFiles.length > 0 ? 10 : 15}
+                maxSize={browseOpenFiles.length > 0 ? 40 : undefined}
+              >
+                <BrowseFileListPanel />
+              </Panel>
+            )}
           </PanelGroup>
-        ) : (
-          /* Browse mode with file selected - 3 panel layout */
-          <PanelGroup direction="horizontal" autoSaveId="main-layout">
-            <Panel defaultSize={40} minSize={20}>
-              <TerminalTabs ref={terminalTabsRef} />
-            </Panel>
-
-            <PanelResizeHandle />
-
-            <Panel defaultSize={40} minSize={20}>
-              <BrowseEditorTabs ref={browseEditorTabsRef} />
-            </Panel>
-
-            <PanelResizeHandle />
-
-            <Panel defaultSize={20} minSize={10} maxSize={40}>
-              <BrowseFileListPanel />
-            </Panel>
-          </PanelGroup>
-        )}
+        </DiffViewerProvider>
       </div>
 
       {/* Keyboard Shortcuts Modal */}

--- a/src/hooks/useDiffViewerState.ts
+++ b/src/hooks/useDiffViewerState.ts
@@ -11,7 +11,7 @@ export interface FileWithCategory {
   category: 'staged' | 'unstaged' | 'untracked';
 }
 
-export function useDiffViewerState(gitPolling: GitPollingResult) {
+export function useDiffViewerState(gitPolling: GitPollingResult, enabled: boolean = true) {
   const { currentDirectory, contextPath } = useFileStore();
   const {
     collapsedDiffFiles,
@@ -37,23 +37,26 @@ export function useDiffViewerState(gitPolling: GitPollingResult) {
 
   // Load all diffs when files change (expanded by default)
   useEffect(() => {
+    if (!enabled) return;
     if (allFiles.length > 0) {
       allFiles.forEach((file) => {
         loadDiff(file.path);
       });
     }
-  }, [allFiles, loadDiff]);
+  }, [allFiles, loadDiff, enabled]);
 
   // Reset when context path changes
   useEffect(() => {
+    if (!enabled) return;
     clearDiffs();
-  }, [contextPath, clearDiffs]);
+  }, [contextPath, clearDiffs, enabled]);
 
   useEffect(() => {
+    if (!enabled) return;
     if (contextPath) {
       refresh();
     }
-  }, [contextPath, refresh]);
+  }, [contextPath, refresh, enabled]);
 
   // Handle scroll-to-file using Virtuoso
   useEffect(() => {


### PR DESCRIPTION
Replace the 4-branch conditional rendering in MainLayout with a single always-mounted PanelGroup so the terminal panel never unmounts when toggling between Diff/Browse/terminal-only modes. Gate DiffViewerProvider effects with an `enabled` prop to avoid loading diffs when not in diff mode.