### PR TITLE
feat: place duplicated terminal tab next to the active tab

### DIFF
--- a/src/components/Terminal/TerminalTabs.tsx
+++ b/src/components/Terminal/TerminalTabs.tsx
@@ -78,7 +78,7 @@ export const TerminalTabs = forwardRef<TerminalTabsHandle>(function TerminalTabs
   const handleDuplicateTerminal = useCallback(() => {
     const activeTab = tabs.find((t) => t.id === activeTabId);
     if (!activeTab) return;
-    createTerminal(activeTab.worktreePath, activeTab.projectId);
+    createTerminal(activeTab.worktreePath, activeTab.projectId, activeTabId ?? undefined);
   }, [tabs, activeTabId, createTerminal]);
 
   const handleNewTerminal = useCallback(() => {

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -260,10 +260,10 @@ export function useCreateTerminal() {
   const addTab = useTerminalStore((state) => state.addTab);
 
   const create = useCallback(
-    async (worktreePath: string, projectId: string | null = null) => {
+    async (worktreePath: string, projectId: string | null = null, afterTabId?: string) => {
       try {
         const id = await createTerminalBackend(worktreePath);
-        addTab(id, worktreePath, projectId);
+        addTab(id, worktreePath, projectId, afterTabId);
         return id;
       } catch (err) {
         console.error('Failed to create terminal:', err);

--- a/src/stores/terminalStore.ts
+++ b/src/stores/terminalStore.ts
@@ -10,7 +10,7 @@ export interface TerminalTab {
 interface TerminalState {
   tabs: TerminalTab[];
   activeTabId: string | null;
-  addTab: (id: string, worktreePath: string, projectId: string | null) => void;
+  addTab: (id: string, worktreePath: string, projectId: string | null, afterTabId?: string) => void;
   removeTab: (id: string) => void;
   setActiveTab: (id: string) => void;
   setTabTitle: (id: string, title: string) => void;
@@ -21,11 +21,19 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
   tabs: [],
   activeTabId: null,
 
-  addTab: (id: string, worktreePath: string, projectId: string | null) => {
-    set({
-      tabs: [...get().tabs, { id, worktreePath, projectId }],
-      activeTabId: id,
-    });
+  addTab: (id: string, worktreePath: string, projectId: string | null, afterTabId?: string) => {
+    const tabs = get().tabs;
+    const newTab = { id, worktreePath, projectId };
+    if (afterTabId) {
+      const afterIndex = tabs.findIndex((t) => t.id === afterTabId);
+      if (afterIndex !== -1) {
+        const newTabs = [...tabs];
+        newTabs.splice(afterIndex + 1, 0, newTab);
+        set({ tabs: newTabs, activeTabId: id });
+        return;
+      }
+    }
+    set({ tabs: [...tabs, newTab], activeTabId: id });
   },
 
   removeTab: (id: string) => {


### PR DESCRIPTION
## Summary
- When duplicating a terminal tab (Cmd+D), the new tab is now inserted immediately after the active tab instead of being appended to the end
- Adds an optional `afterTabId` parameter to `addTab` and `createTerminal`, which splices the new tab into the correct position
- New terminal creation (Cmd+T) is unchanged and still appends to the end

## Test plan
- [ ] Open the app and create 3+ terminal tabs
- [ ] Select the first or middle tab, press Cmd+D
- [ ] Confirm the new tab appears immediately after the selected tab, not at the end
- [ ] Confirm creating a new terminal via Cmd+T still appends to the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)