### PR TITLE
feat: dim git-ignored files in file browser

### DIFF
--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -1,5 +1,6 @@
 use crate::error::impl_serialize_as_string;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
+use git2::Repository;
 use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -45,6 +46,7 @@ pub struct FileEntry {
     pub path: String,
     pub is_directory: bool,
     pub is_symlink: bool,
+    pub is_gitignored: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub children: Option<Vec<FileEntry>>,
 }
@@ -73,6 +75,8 @@ impl FileSystemManager {
             return Err(FileSystemError::NotFound(path.display().to_string()));
         }
 
+        let repo = Repository::discover(&path).ok();
+
         let mut entries = Vec::new();
         let walker = WalkBuilder::new(&path)
             .max_depth(Some(1))
@@ -92,11 +96,17 @@ impl FileSystemManager {
                 .map(|n| n.to_string_lossy().to_string())
                 .unwrap_or_default();
 
+            let is_gitignored = repo
+                .as_ref()
+                .and_then(|r| r.status_should_ignore(entry_path).ok())
+                .unwrap_or(false);
+
             entries.push(FileEntry {
                 name,
                 path: entry_path.display().to_string(),
                 is_directory: metadata.is_dir(),
                 is_symlink: metadata.is_symlink(),
+                is_gitignored,
                 children: None,
             });
         }

--- a/src/components/DiffViewer/DiffFileList.tsx
+++ b/src/components/DiffViewer/DiffFileList.tsx
@@ -152,6 +152,7 @@ function FileTreeItem({
                 path: node.path,
                 isDirectory: false,
                 isSymlink: false,
+                isGitignored: false,
               });
             }
           : undefined

--- a/src/components/FileBrowser/BrowseFileListPanel.tsx
+++ b/src/components/FileBrowser/BrowseFileListPanel.tsx
@@ -65,7 +65,7 @@ function BrowseFileList({
           }}
           className={`flex w-full select-none items-center gap-1 py-0.5 pr-2 text-left text-sm hover:bg-surface-3/50 ${
             isActive || isContextTarget ? 'bg-surface-3' : isOpen ? 'bg-surface-3/30' : ''
-          }`}
+          } ${entry.isGitignored ? 'opacity-50' : ''}`}
           style={{ paddingLeft: `${depth * 12 + 8}px` }}
         >
           {entry.isDirectory && (

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -39,6 +39,7 @@ export interface FileEntry {
   path: string;
   isDirectory: boolean;
   isSymlink: boolean;
+  isGitignored: boolean;
   children?: FileEntry[];
 }
 


### PR DESCRIPTION
## Summary
- Detect git-ignored files using `git2`'s `status_should_ignore()` in the Rust backend and expose an `isGitignored` field on `FileEntry`
- Apply `opacity-50` to ignored file entries in the browse file list, dimming their name, icon, and chevron
- Files like `node_modules/`, `target/`, `dist/` now appear visually muted while tracked files remain at full opacity

## Test plan
- [ ] Open a project with a `.gitignore` file
- [ ] Verify files/folders matching gitignore patterns (e.g. `node_modules/`, `target/`, `dist/`) appear dimmed
- [ ] Verify tracked and untracked (but not ignored) files appear at full opacity
- [ ] Expand a git-ignored directory and confirm children also appear dimmed
- [ ] Open a non-git directory and confirm all files appear at full opacity with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)