### PR TITLE
feat: add Cmd+Click URL opening in terminal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.10.0",
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.18.0",
         "@xterm/xterm": "^5.5.0",
         "diff": "^8.0.3",
@@ -2367,6 +2368,12 @@
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
       }
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
+      "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {
       "version": "0.18.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.10.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.18.0",
     "@xterm/xterm": "^5.5.0",
     "diff": "^8.0.3",

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -2,6 +2,8 @@ import { useEffect, useRef, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { WebglAddon } from '@xterm/addon-webgl';
+import { WebLinksAddon } from '@xterm/addon-web-links';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import {
   createTerminal as createTerminalBackend,
   writeToTerminal,
@@ -169,6 +171,12 @@ export function useTerminal(containerId: string | null) {
       } catch (e) {
         console.warn('WebGL addon failed to load, using canvas renderer:', e);
       }
+
+      // Load web links addon for Cmd+Click URL opening
+      const webLinksAddon = new WebLinksAddon((_event, uri) => {
+        openUrl(uri).catch(console.error);
+      });
+      terminal.loadAddon(webLinksAddon);
 
       terminalRef.current = terminal;
       fitAddonRef.current = fitAddon;


### PR DESCRIPTION
## Summary
- Add `@xterm/addon-web-links` to detect and underline URLs in terminal output on hover
- Cmd+Click opens the URL in the default browser via `@tauri-apps/plugin-opener`

## Test plan
- [ ] Run `npm run dev:desktop`
- [ ] In a terminal tab, run `echo https://google.com`
- [ ] Hover over the URL — it should underline
- [ ] Cmd+Click the URL — it should open in the default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)