### PR TITLE
feat: add merge conflict resolution UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amend",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amend",
-      "version": "0.1.10",
+      "version": "0.1.12",
       "dependencies": {
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-css": "^6.3.1",

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -41,6 +41,7 @@ pub struct GitStatus {
     pub staged: Vec<GitFileStatus>,
     pub unstaged: Vec<GitFileStatus>,
     pub untracked: Vec<String>,
+    pub conflicted: Vec<String>,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -136,11 +137,17 @@ pub fn get_git_status(repo_path: String) -> Result<GitStatus, GitError> {
         staged: Vec::new(),
         unstaged: Vec::new(),
         untracked: Vec::new(),
+        conflicted: Vec::new(),
     };
 
     for entry in statuses.iter() {
         let path = entry.path().unwrap_or("").to_string();
         let status = entry.status();
+
+        if status.is_conflicted() {
+            result.conflicted.push(path);
+            continue;
+        }
 
         if status.is_wt_new() {
             result.untracked.push(path);
@@ -379,6 +386,13 @@ pub fn restore_file(repo_path: String, file_path: String) -> Result<(), GitError
 pub fn unstage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
     validate_no_flag(&file_path, "file path")?;
     run_git_command(&repo_path, &["restore", "--staged", "--", &file_path])?;
+    Ok(())
+}
+
+#[tauri::command]
+pub fn stage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
+    validate_no_flag(&file_path, "file path")?;
+    run_git_command(&repo_path, &["add", "--", &file_path])?;
     Ok(())
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -51,6 +51,7 @@ pub fn run() {
             git::list_branches,
             git::restore_file,
             git::unstage_file,
+            git::stage_file,
             git::get_diff_stats,
             // Watcher commands
             watcher::start_watching_directory,

--- a/src/components/DiffViewer/DiffContentPanel.tsx
+++ b/src/components/DiffViewer/DiffContentPanel.tsx
@@ -8,12 +8,14 @@ import '@/styles/highlight-theme.css';
 export function DiffContentPanel() {
   const {
     currentDirectory,
+    contextPath,
     allFiles,
     diffs,
     collapsedDiffFiles,
     virtuosoRef,
     toggleDiffFileCollapse,
     handleEditFile,
+    handleRefresh,
   } = useDiffViewer();
   const { diffFileListVisible, toggleDiffFileList, setFocusedPanel } = useUIStore();
 
@@ -85,6 +87,8 @@ export function DiffContentPanel() {
                 error={diffData?.error ?? null}
                 onToggleCollapse={() => toggleDiffFileCollapse(file.path)}
                 onEditFile={handleEditFile}
+                repoPath={contextPath || ''}
+                onRefresh={handleRefresh}
               />
             );
           }}

--- a/src/components/DiffViewer/DiffFileList.tsx
+++ b/src/components/DiffViewer/DiffFileList.tsx
@@ -70,6 +70,7 @@ const STATUS_DISPLAY: Record<string, { color: string; letter: string }> = {
   modified: { color: 'text-amber-500 dark:text-yellow-400', letter: 'M' },
   deleted: { color: 'text-diff-remove-text', letter: 'D' },
   renamed: { color: 'text-blue-600 dark:text-blue-400', letter: 'R' },
+  conflicted: { color: 'text-red-500 dark:text-red-400', letter: 'C' },
 };
 
 function getStatusIcon(statusType: string) {
@@ -254,6 +255,14 @@ export function DiffFileList({
     return buildTree(status.untracked, { getPath: (p) => p });
   }, [status]);
 
+  const conflictedTree = useMemo(() => {
+    if (!status || (status.conflicted?.length ?? 0) === 0) return null;
+    return buildTree(status.conflicted, {
+      getPath: (p) => p,
+      getLeafData: () => ({ status: 'conflicted' }),
+    });
+  }, [status]);
+
   if (isLoading) {
     return <div className="flex items-center justify-center h-full text-tertiary">Loading...</div>;
   }
@@ -267,7 +276,10 @@ export function DiffFileList({
   }
 
   const hasChanges =
-    status.staged.length > 0 || status.unstaged.length > 0 || status.untracked.length > 0;
+    (status.conflicted?.length ?? 0) > 0 ||
+    status.staged.length > 0 ||
+    status.unstaged.length > 0 ||
+    status.untracked.length > 0;
 
   if (!hasChanges) {
     return (
@@ -281,6 +293,21 @@ export function DiffFileList({
 
   return (
     <div className="h-full overflow-y-auto">
+      {/* Conflicted files */}
+      {conflictedTree && (status.conflicted?.length ?? 0) > 0 && (
+        <div className="mb-2">
+          <div className="px-3 py-1.5 text-xs font-semibold uppercase tracking-wide text-red-500 dark:text-red-400">
+            Conflicts ({status.conflicted.length})
+          </div>
+          <FileTreeItem
+            node={conflictedTree}
+            depth={0}
+            onScrollToFile={handleScrollToFile}
+            selectedFile={selectedFile}
+          />
+        </div>
+      )}
+
       {/* Staged changes */}
       {stagedTree && status.staged.length > 0 && (
         <div className="mb-2">

--- a/src/components/DiffViewer/DiffFileSection.tsx
+++ b/src/components/DiffViewer/DiffFileSection.tsx
@@ -3,10 +3,17 @@ import * as Diff from 'diff';
 import { highlightCode, getLanguageFromPath } from '@/lib/highlight';
 import { getFileName, toggleSetItem, buildImageDataUrl } from '@/lib/fileUtils';
 import { ChevronIcon } from '@/components/Icons';
+import {
+  parseConflicts,
+  resolveConflict,
+  hasConflictMarkers,
+  FileSegment,
+} from '@/lib/conflictParser';
+import { writeFile, stageFile } from '@/lib/tauri';
 
 interface DiffFileSectionProps {
   filePath: string;
-  category: 'staged' | 'unstaged' | 'untracked';
+  category: 'staged' | 'unstaged' | 'untracked' | 'conflicted';
   oldContent: string;
   newContent: string;
   isBinary: boolean;
@@ -15,6 +22,8 @@ interface DiffFileSectionProps {
   error: string | null;
   onToggleCollapse: () => void;
   onEditFile: (filePath: string) => void;
+  repoPath?: string;
+  onRefresh?: () => void;
 }
 
 interface DiffLineProps {
@@ -120,9 +129,14 @@ const BADGE_CONFIG: Record<string, { bg: string; text: string; label: string }> 
     label: 'Changed',
   },
   untracked: { bg: 'bg-gray-200 dark:bg-gray-600/30', text: 'text-tertiary', label: 'Untracked' },
+  conflicted: {
+    bg: 'bg-red-100 dark:bg-red-600/20',
+    text: 'text-red-600 dark:text-red-400',
+    label: 'Conflict',
+  },
 };
 
-function getStatusBadge(category: 'staged' | 'unstaged' | 'untracked') {
+function getStatusBadge(category: 'staged' | 'unstaged' | 'untracked' | 'conflicted') {
   const config = BADGE_CONFIG[category];
   return (
     <span className={`rounded-md ${config.bg} px-1.5 py-0.5 text-xs font-medium ${config.text}`}>
@@ -289,6 +303,148 @@ const ImageDiffContent = memo(function ImageDiffContent({
   );
 });
 
+// Conflict resolution content component
+const ConflictContent = memo(function ConflictContent({
+  filePath,
+  newContent,
+  repoPath,
+  onRefresh,
+}: {
+  filePath: string;
+  newContent: string;
+  repoPath: string;
+  onRefresh: () => void;
+}) {
+  const [segments, setSegments] = useState<FileSegment[] | null>(null);
+  const [allResolved, setAllResolved] = useState(false);
+  const language = getLanguageFromPath(filePath);
+
+  useEffect(() => {
+    const parsed = parseConflicts(newContent);
+    setSegments(parsed);
+    setAllResolved(!hasConflictMarkers(newContent));
+  }, [newContent]);
+
+  const handleResolve = useCallback(
+    async (conflictIndex: number, resolution: 'ours' | 'theirs' | 'both') => {
+      if (!segments) return;
+      const resolved = resolveConflict(segments, conflictIndex, resolution);
+      const fullPath = `${repoPath}/${filePath}`;
+      await writeFile(fullPath, resolved);
+      onRefresh();
+    },
+    [segments, repoPath, filePath, onRefresh]
+  );
+
+  const handleMarkResolved = useCallback(async () => {
+    await stageFile(repoPath, filePath);
+    onRefresh();
+  }, [repoPath, filePath, onRefresh]);
+
+  if (!segments) {
+    return (
+      <div className="flex items-center justify-center py-4 text-tertiary text-sm">
+        No conflict markers found
+      </div>
+    );
+  }
+
+  let conflictIndex = 0;
+
+  return (
+    <div>
+      {segments.map((segment, i) => {
+        if (segment.kind === 'normal') {
+          return (
+            <div key={i}>
+              {segment.lines.map((line, li) => (
+                <div key={li} className="font-mono text-sm whitespace-nowrap">
+                  <span
+                    className="px-2 whitespace-pre hljs"
+                    dangerouslySetInnerHTML={{ __html: highlightCode(line, language) }}
+                  />
+                </div>
+              ))}
+            </div>
+          );
+        }
+
+        const idx = conflictIndex++;
+        return (
+          <div key={i} className="border-y border-surface-3">
+            {/* Resolution buttons */}
+            <div className="flex items-center gap-2 px-3 py-1.5 bg-surface-2">
+              <span className="text-xs font-medium text-secondary mr-auto">
+                Conflict #{idx + 1}
+              </span>
+              <button
+                onClick={() => handleResolve(idx, 'ours')}
+                className="rounded-md px-2 py-0.5 text-xs font-medium text-conflict-ours-text bg-conflict-ours-bg hover:opacity-80"
+              >
+                Accept Current
+              </button>
+              <button
+                onClick={() => handleResolve(idx, 'theirs')}
+                className="rounded-md px-2 py-0.5 text-xs font-medium text-conflict-theirs-text bg-conflict-theirs-bg hover:opacity-80"
+              >
+                Accept Incoming
+              </button>
+              <button
+                onClick={() => handleResolve(idx, 'both')}
+                className="rounded-md px-2 py-0.5 text-xs font-medium text-secondary bg-surface-3 hover:opacity-80"
+              >
+                Accept Both
+              </button>
+            </div>
+
+            {/* Ours section */}
+            <div className="bg-conflict-ours-bg">
+              <div className="px-3 py-0.5 text-xs text-conflict-ours-text font-medium border-b border-conflict-ours-text/20">
+                Current ({segment.oursLabel})
+              </div>
+              {segment.oursLines.map((line, li) => (
+                <div key={li} className="font-mono text-sm whitespace-nowrap">
+                  <span
+                    className="px-2 whitespace-pre hljs"
+                    dangerouslySetInnerHTML={{ __html: highlightCode(line, language) }}
+                  />
+                </div>
+              ))}
+            </div>
+
+            {/* Theirs section */}
+            <div className="bg-conflict-theirs-bg">
+              <div className="px-3 py-0.5 text-xs text-conflict-theirs-text font-medium border-b border-conflict-theirs-text/20">
+                Incoming ({segment.theirsLabel})
+              </div>
+              {segment.theirsLines.map((line, li) => (
+                <div key={li} className="font-mono text-sm whitespace-nowrap">
+                  <span
+                    className="px-2 whitespace-pre hljs"
+                    dangerouslySetInnerHTML={{ __html: highlightCode(line, language) }}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      {/* Mark as Resolved button when all conflicts are resolved */}
+      {allResolved && (
+        <div className="flex items-center justify-center py-3 bg-surface-1">
+          <button
+            onClick={handleMarkResolved}
+            className="rounded-md px-3 py-1.5 text-xs font-medium text-white bg-green-600 hover:bg-green-700"
+          >
+            Mark as Resolved
+          </button>
+        </div>
+      )}
+    </div>
+  );
+});
+
 export const DiffFileSection = memo(function DiffFileSection({
   filePath,
   category,
@@ -300,6 +456,8 @@ export const DiffFileSection = memo(function DiffFileSection({
   error,
   onToggleCollapse,
   onEditFile,
+  repoPath,
+  onRefresh,
 }: DiffFileSectionProps) {
   // Expand state for collapsed sections
   const [expandedSections, setExpandedSections] = useState<Set<number>>(new Set());
@@ -497,7 +655,16 @@ export const DiffFileSection = memo(function DiffFileSection({
             <ImageDiffContent filePath={filePath} oldContent={oldContent} newContent={newContent} />
           )}
 
-          {hasContent && !isBinary && (
+          {hasContent && !isBinary && category === 'conflicted' && repoPath && onRefresh && (
+            <ConflictContent
+              filePath={filePath}
+              newContent={newContent}
+              repoPath={repoPath}
+              onRefresh={onRefresh}
+            />
+          )}
+
+          {hasContent && !isBinary && category !== 'conflicted' && (
             <DiffContent
               sections={sections}
               expandedSections={expandedSections}

--- a/src/hooks/useDiffViewerState.ts
+++ b/src/hooks/useDiffViewerState.ts
@@ -8,7 +8,7 @@ import { GitPollingResult } from '@/hooks/useGit';
 
 export interface FileWithCategory {
   path: string;
-  category: 'staged' | 'unstaged' | 'untracked';
+  category: 'staged' | 'unstaged' | 'untracked' | 'conflicted';
 }
 
 export function useDiffViewerState(gitPolling: GitPollingResult, enabled: boolean = true) {
@@ -29,6 +29,7 @@ export function useDiffViewerState(gitPolling: GitPollingResult, enabled: boolea
   const allFiles = useMemo((): FileWithCategory[] => {
     if (!status) return [];
     return [
+      ...status.conflicted.map((path) => ({ path, category: 'conflicted' as const })),
       ...status.staged.map((f) => ({ path: f.path, category: 'staged' as const })),
       ...status.unstaged.map((f) => ({ path: f.path, category: 'unstaged' as const })),
       ...status.untracked.map((path) => ({ path, category: 'untracked' as const })),

--- a/src/hooks/useGit.ts
+++ b/src/hooks/useGit.ts
@@ -41,7 +41,9 @@ export function useGitPolling(repoPath: string | null) {
           '||' +
           gitStatus.unstaged.map((f) => `${f.path}:${f.status}`).join('|') +
           '||' +
-          gitStatus.untracked.join('|');
+          gitStatus.untracked.join('|') +
+          '||' +
+          gitStatus.conflicted.join('|');
         if (statusKey !== lastStatusRef.current) {
           lastStatusRef.current = statusKey;
           setStatus(gitStatus);

--- a/src/index.css
+++ b/src/index.css
@@ -29,6 +29,12 @@
   --diff-remove-bg: #ffebe9;
   --diff-remove-text: #cf222e;
 
+  /* Conflict colors - light */
+  --conflict-ours-bg: #dbeafe;
+  --conflict-ours-text: #1d4ed8;
+  --conflict-theirs-bg: #fce7f3;
+  --conflict-theirs-text: #be185d;
+
   color-scheme: light;
   color: var(--text-primary);
   background-color: var(--surface-0);
@@ -51,6 +57,12 @@
   --diff-add-text: #7ee787;
   --diff-remove-bg: rgba(248, 81, 73, 0.15);
   --diff-remove-text: #ff7b72;
+
+  /* Conflict colors - dark */
+  --conflict-ours-bg: rgba(59, 130, 246, 0.15);
+  --conflict-ours-text: #93c5fd;
+  --conflict-theirs-bg: rgba(236, 72, 153, 0.15);
+  --conflict-theirs-text: #f9a8d4;
 
   color-scheme: dark;
   color: var(--text-primary);

--- a/src/lib/conflictParser.ts
+++ b/src/lib/conflictParser.ts
@@ -1,0 +1,137 @@
+export interface NormalSegment {
+  kind: 'normal';
+  lines: string[];
+}
+
+export interface ConflictSegment {
+  kind: 'conflict';
+  oursLabel: string;
+  theirsLabel: string;
+  oursLines: string[];
+  theirsLines: string[];
+}
+
+export type FileSegment = NormalSegment | ConflictSegment;
+
+const OURS_MARKER = /^<{7}\s?(.*)/;
+const SEPARATOR = /^={7}$/;
+const THEIRS_MARKER = /^>{7}\s?(.*)/;
+
+export function parseConflicts(content: string): FileSegment[] | null {
+  const lines = content.split('\n');
+  const segments: FileSegment[] = [];
+  let normalLines: string[] = [];
+  let foundConflict = false;
+
+  let i = 0;
+  while (i < lines.length) {
+    const oursMatch = lines[i].match(OURS_MARKER);
+    if (oursMatch) {
+      // Flush any accumulated normal lines
+      if (normalLines.length > 0) {
+        segments.push({ kind: 'normal', lines: normalLines });
+        normalLines = [];
+      }
+
+      const oursLabel = oursMatch[1] || 'Current Change';
+      const oursLines: string[] = [];
+      i++;
+
+      // Collect ours lines until separator
+      while (i < lines.length && !SEPARATOR.test(lines[i])) {
+        oursLines.push(lines[i]);
+        i++;
+      }
+
+      if (i >= lines.length) {
+        // Malformed: no separator found, treat as normal text
+        normalLines.push(lines[i - oursLines.length - 1]);
+        normalLines.push(...oursLines);
+        continue;
+      }
+
+      // Skip separator
+      i++;
+
+      const theirsLines: string[] = [];
+      // Collect theirs lines until theirs marker
+      while (i < lines.length && !THEIRS_MARKER.test(lines[i])) {
+        theirsLines.push(lines[i]);
+        i++;
+      }
+
+      if (i >= lines.length) {
+        // Malformed: no theirs marker found, treat as normal text
+        normalLines.push(`<<<<<<< ${oursLabel}`);
+        normalLines.push(...oursLines);
+        normalLines.push('=======');
+        normalLines.push(...theirsLines);
+        continue;
+      }
+
+      const theirsMatch = lines[i].match(THEIRS_MARKER);
+      const theirsLabel = theirsMatch?.[1] || 'Incoming Change';
+      i++;
+
+      segments.push({
+        kind: 'conflict',
+        oursLabel,
+        theirsLabel,
+        oursLines,
+        theirsLines,
+      });
+      foundConflict = true;
+    } else {
+      normalLines.push(lines[i]);
+      i++;
+    }
+  }
+
+  // Flush remaining normal lines
+  if (normalLines.length > 0) {
+    segments.push({ kind: 'normal', lines: normalLines });
+  }
+
+  return foundConflict ? segments : null;
+}
+
+export function resolveConflict(
+  segments: FileSegment[],
+  conflictIndex: number,
+  resolution: 'ours' | 'theirs' | 'both'
+): string {
+  let conflictCount = 0;
+  const outputLines: string[] = [];
+
+  for (const segment of segments) {
+    if (segment.kind === 'normal') {
+      outputLines.push(...segment.lines);
+    } else {
+      if (conflictCount === conflictIndex) {
+        // Resolve this conflict
+        if (resolution === 'ours') {
+          outputLines.push(...segment.oursLines);
+        } else if (resolution === 'theirs') {
+          outputLines.push(...segment.theirsLines);
+        } else {
+          outputLines.push(...segment.oursLines);
+          outputLines.push(...segment.theirsLines);
+        }
+      } else {
+        // Preserve this conflict with markers
+        outputLines.push(`<<<<<<< ${segment.oursLabel}`);
+        outputLines.push(...segment.oursLines);
+        outputLines.push('=======');
+        outputLines.push(...segment.theirsLines);
+        outputLines.push(`>>>>>>> ${segment.theirsLabel}`);
+      }
+      conflictCount++;
+    }
+  }
+
+  return outputLines.join('\n');
+}
+
+export function hasConflictMarkers(content: string): boolean {
+  return /^<{7}\s/m.test(content);
+}

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -124,6 +124,7 @@ export interface GitStatus {
   staged: GitFileStatus[];
   unstaged: GitFileStatus[];
   untracked: string[];
+  conflicted: string[];
 }
 
 export interface GitFileStatus {
@@ -195,6 +196,10 @@ export async function restoreFile(repoPath: string, filePath: string): Promise<v
 
 export async function unstageFile(repoPath: string, filePath: string): Promise<void> {
   return invoke('unstage_file', { repoPath, filePath });
+}
+
+export async function stageFile(repoPath: string, filePath: string): Promise<void> {
+  return invoke('stage_file', { repoPath, filePath });
 }
 
 export interface DiffStats {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -30,6 +30,14 @@ export default {
           bg: 'var(--diff-remove-bg)',
           text: 'var(--diff-remove-text)',
         },
+        'conflict-ours': {
+          bg: 'var(--conflict-ours-bg)',
+          text: 'var(--conflict-ours-text)',
+        },
+        'conflict-theirs': {
+          bg: 'var(--conflict-theirs-bg)',
+          text: 'var(--conflict-theirs-text)',
+        },
       },
       fontFamily: {
         'mono': ['Menlo', 'Monaco', 'Consolas', 'Liberation Mono', 'Courier New', 'monospace'],


### PR DESCRIPTION
## Summary
- Detects conflicted files during merge/rebase via git2's `is_conflicted()` and surfaces them in a new "Conflicts" sidebar section with red status icons
- Adds a `ConflictContent` component that parses `<<<<<<<`/`=======`/`>>>>>>>` markers and renders ours (blue) / theirs (pink) sections with syntax highlighting
- Provides inline resolution buttons (Accept Current, Accept Incoming, Accept Both) that write resolved content to disk, plus a "Mark as Resolved" button that stages the file
- Adds `stage_file` Tauri command and IPC wrapper, conflict color tokens for light/dark themes

## Test plan
- [ ] Create a merge conflict in a test repo (conflicting changes on two branches, attempt merge)
- [ ] Verify conflicted files appear in "Conflicts" section at top of file list sidebar with red "C" icon
- [ ] Verify conflict regions render with blue (ours) and pink (theirs) backgrounds and resolution buttons
- [ ] Click "Accept Current", "Accept Incoming", and "Accept Both" — verify file updates correctly on disk
- [ ] After resolving all conflicts, click "Mark as Resolved" — verify file moves from Conflicts to Staged
- [ ] Verify colors in both light and dark mode
- [ ] Run `tsc --noEmit` and `cargo check` — both pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)