### PR TITLE
fix: file content panel full width and gutter alignment

### DIFF
--- a/src/components/FileBrowser/FileContentPanel.tsx
+++ b/src/components/FileBrowser/FileContentPanel.tsx
@@ -99,5 +99,5 @@ export function FileContentPanel({
     );
   }
 
-  return <div ref={containerRef} className="h-full" />;
+  return <div ref={containerRef} className="h-full w-full" />;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -122,6 +122,7 @@ body,
 /* CodeMirror overrides */
 .cm-editor {
   height: 100%;
+  width: 100%;
 }
 
 .cm-scroller {

--- a/src/lib/codemirror.ts
+++ b/src/lib/codemirror.ts
@@ -310,6 +310,10 @@ const stickyGutters = ViewPlugin.fromClass(
       wrapper.appendChild(gutterClip);
       wrapper.appendChild(scroller);
 
+      // Make the scroller fill the remaining width after the gutter
+      scroller.style.flex = '1';
+      scroller.style.minWidth = '0';
+
       // Sync vertical scroll
       scroller.addEventListener('scroll', this.syncScroll, { passive: true });
       this.syncScroll();


### PR DESCRIPTION
## Summary
- Ensure the file content editor always fills the full width of the panel, even when file content is narrower than the available space
- Pin the line number gutter to the left by making the scroller fill remaining width in the sticky gutters flex layout

## Test plan
- [ ] Open a file with short lines (e.g. a small config file) and verify the editor fills the full panel width
- [ ] Verify the line number gutter stays pinned to the left side in all cases
- [ ] Test with files of varying widths to confirm consistent layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)