### PR TITLE
refactor: extract shared file tree primitives

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amend",
-  "version": "0.1.15",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amend",
-      "version": "0.1.15",
+      "version": "0.1.18",
       "dependencies": {
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/components/DiffViewer/DiffFileList.tsx
+++ b/src/components/DiffViewer/DiffFileList.tsx
@@ -4,7 +4,8 @@ import { sortDirectoriesFirst, getFileName } from '@/lib/fileUtils';
 import { useUIStore } from '@/stores/uiStore';
 import { ContextMenu } from '@/components/ContextMenu/ContextMenu';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
-import { ChevronIcon, FolderIcon, DiscardIcon } from '@/components/Icons';
+import { DiscardIcon } from '@/components/Icons';
+import { TreeRow, DirectoryIndicator } from '@/components/FileTree/TreePrimitives';
 
 interface DiffFileListProps {
   status: GitStatus | null;
@@ -165,17 +166,10 @@ function FileTreeItem({
     return (
       <div>
         {node.name && (
-          <button
-            onClick={() => toggleDiffTreePath(node.path)}
-            className="flex w-full select-none items-center gap-1 px-2 py-0.5 text-sm hover:bg-surface-3/50"
-            style={{ paddingLeft: `${depth * 12 + 8}px` }}
-          >
-            <ChevronIcon
-              className={`h-3 w-3 text-tertiary transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-            />
-            <FolderIcon className="h-4 w-4 text-yellow-500" />
+          <TreeRow depth={depth} onClick={() => toggleDiffTreePath(node.path)}>
+            <DirectoryIndicator isExpanded={isExpanded} />
             <span className="text-primary">{node.name}</span>
-          </button>
+          </TreeRow>
         )}
         {(isExpanded || !node.name) && (
           <div>
@@ -207,7 +201,10 @@ function FileTreeItem({
   const inlineAction: 'restore' | 'unstage' = hasUnstaged ? 'restore' : 'unstage';
 
   return (
-    <button
+    <TreeRow
+      depth={depth}
+      isSelected={isSelected}
+      className="group"
       onClick={() => onScrollToFile(node.path)}
       onContextMenu={
         onContextMenu
@@ -218,10 +215,6 @@ function FileTreeItem({
             }
           : undefined
       }
-      className={`group flex w-full select-none items-center gap-1 py-0.5 text-sm hover:bg-surface-3/50 ${
-        isSelected ? 'bg-surface-3' : ''
-      }`}
-      style={{ paddingLeft: `${depth * 12 + 8}px` }}
     >
       {getStatusIndicator(categories)}
       <span className="truncate text-primary flex-1 text-left">{node.name}</span>
@@ -239,7 +232,7 @@ function FileTreeItem({
           <DiscardIcon />
         </span>
       )}
-    </button>
+    </TreeRow>
   );
 }
 

--- a/src/components/DiffViewer/DiffFileListPanel.tsx
+++ b/src/components/DiffViewer/DiffFileListPanel.tsx
@@ -1,7 +1,7 @@
 import { useDiffViewer } from './DiffViewerContext';
 import { DiffFileList } from './DiffFileList';
-import { RefreshIcon } from '@/components/Icons';
 import { useUIStore } from '@/stores/uiStore';
+import { PanelHeader } from '@/components/FileTree/TreePrimitives';
 
 export function DiffFileListPanel() {
   const { status, statusLoading, allFiles, contextPath, handleRefresh, handleScrollToFile } =
@@ -13,25 +13,7 @@ export function DiffFileListPanel() {
 
   return (
     <div className="h-full bg-surface-2 flex flex-col">
-      <div className="flex items-center justify-between px-3 py-2">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-primary">
-            Changes
-          </span>
-          {changedFilesCount > 0 && (
-            <span className="rounded-full bg-green-600 px-2 py-0.5 text-xs font-medium text-white">
-              {changedFilesCount}
-            </span>
-          )}
-        </div>
-        <button
-          onClick={handleRefresh}
-          className="rounded-md p-1 text-secondary hover:bg-surface-3"
-          title="Refresh"
-        >
-          <RefreshIcon />
-        </button>
-      </div>
+      <PanelHeader title="Changes" badge={changedFilesCount} onRefresh={handleRefresh} />
       <div className="flex-1 overflow-y-auto">
         <DiffFileList
           status={status}

--- a/src/components/FileBrowser/BrowseFileListPanel.tsx
+++ b/src/components/FileBrowser/BrowseFileListPanel.tsx
@@ -5,7 +5,8 @@ import { readDirectories, FileEntry } from '@/lib/tauri';
 import { useContextMenuStore } from '@/stores/contextMenuStore';
 import { useUIStore } from '@/stores/uiStore';
 import { getFileIconColor, sortDirectoriesFirst } from '@/lib/fileUtils';
-import { ChevronIcon, FolderIcon, FileIcon, RefreshIcon } from '@/components/Icons';
+import { FolderIcon, FileIcon } from '@/components/Icons';
+import { TreeRow, DirectoryIndicator, PanelHeader } from '@/components/FileTree/TreePrimitives';
 
 const dirContentsCache = new Map<string, FileEntry[]>();
 
@@ -113,34 +114,29 @@ function BrowseFileList({
         const isActive = activeFilePath === entry.path;
         const isContextTarget = contextMenuOpen && contextTargetPath === entry.path;
 
-        const iconEl = entry.isDirectory ? (
-          <FolderIcon className="h-4 w-4 text-yellow-500" />
-        ) : (
-          <FileIcon className={`h-4 w-4 ${getFileIconColor(entry.name)}`} />
-        );
-
         return (
-          <button
+          <TreeRow
+            depth={depth}
+            isSelected={isActive || isContextTarget}
+            isSubtle={isOpen && !isActive && !isContextTarget}
+            className={`pr-2 text-left ${entry.isGitignored ? 'opacity-50' : ''}`}
             onClick={() => (entry.isDirectory ? toggleDir(entry.path) : onSelectFile(entry.path))}
             onContextMenu={(e) => {
               e.preventDefault();
               e.stopPropagation();
               openMenu(entry, e.clientX, e.clientY);
             }}
-            className={`flex w-full select-none items-center gap-1 py-0.5 pr-2 text-left text-sm hover:bg-surface-3/50 ${
-              isActive || isContextTarget ? 'bg-surface-3' : isOpen ? 'bg-surface-3/30' : ''
-            } ${entry.isGitignored ? 'opacity-50' : ''}`}
-            style={{ paddingLeft: `${depth * 12 + 8}px` }}
           >
-            {entry.isDirectory && (
-              <ChevronIcon
-                className={`h-3 w-3 text-tertiary transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-              />
+            {entry.isDirectory ? (
+              <DirectoryIndicator isExpanded={isExpanded} />
+            ) : (
+              <>
+                <span className="w-3" />
+                <FileIcon className={`h-4 w-4 ${getFileIconColor(entry.name)}`} />
+              </>
             )}
-            {!entry.isDirectory && <span className="w-3" />}
-            {iconEl}
             <span className="truncate text-primary">{entry.name}</span>
-          </button>
+          </TreeRow>
         );
       }}
     />
@@ -169,18 +165,7 @@ export function BrowseFileListPanel() {
       className="h-full bg-surface-2 flex flex-col"
       onMouseDown={() => setFocusedPanel('file-list')}
     >
-      <div className="flex items-center justify-between px-3 py-2">
-        <div className="flex items-center gap-2">
-          <span className="text-xs font-semibold uppercase tracking-wide text-primary">Files</span>
-        </div>
-        <button
-          onClick={handleRefresh}
-          className="rounded-md p-1 text-secondary hover:bg-surface-3"
-          title="Refresh"
-        >
-          <RefreshIcon />
-        </button>
-      </div>
+      <PanelHeader title="Files" onRefresh={handleRefresh} />
       {!contextPath ? (
         <div className="flex h-full flex-col items-center justify-center px-6 text-center">
           <FolderIcon className="h-12 w-12 text-tertiary mb-4" />

--- a/src/components/FileTree/TreePrimitives.tsx
+++ b/src/components/FileTree/TreePrimitives.tsx
@@ -1,0 +1,75 @@
+import { type ReactNode } from 'react';
+import { ChevronIcon, FolderIcon, RefreshIcon } from '@/components/Icons';
+
+interface TreeRowProps {
+  depth: number;
+  isSelected?: boolean;
+  isSubtle?: boolean;
+  className?: string;
+  onClick: () => void;
+  onContextMenu?: (e: React.MouseEvent) => void;
+  children: ReactNode;
+}
+
+export function TreeRow({
+  depth,
+  isSelected,
+  isSubtle,
+  className,
+  onClick,
+  onContextMenu,
+  children,
+}: TreeRowProps) {
+  return (
+    <button
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      className={`flex w-full select-none items-center gap-1 py-0.5 text-sm hover:bg-surface-3/50 ${
+        isSelected ? 'bg-surface-3' : isSubtle ? 'bg-surface-3/30' : ''
+      } ${className ?? ''}`}
+      style={{ paddingLeft: `${depth * 12 + 8}px` }}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function DirectoryIndicator({ isExpanded }: { isExpanded: boolean }) {
+  return (
+    <>
+      <ChevronIcon
+        className={`h-3 w-3 text-tertiary transition-transform ${isExpanded ? 'rotate-90' : ''}`}
+      />
+      <FolderIcon className="h-4 w-4 text-yellow-500" />
+    </>
+  );
+}
+
+interface PanelHeaderProps {
+  title: string;
+  badge?: number;
+  badgeColor?: string;
+  onRefresh: () => void;
+}
+
+export function PanelHeader({ title, badge, badgeColor = 'bg-green-600', onRefresh }: PanelHeaderProps) {
+  return (
+    <div className="flex items-center justify-between px-3 py-2">
+      <div className="flex items-center gap-2">
+        <span className="text-xs font-semibold uppercase tracking-wide text-primary">{title}</span>
+        {badge != null && badge > 0 && (
+          <span className={`rounded-full ${badgeColor} px-2 py-0.5 text-xs font-medium text-white`}>
+            {badge}
+          </span>
+        )}
+      </div>
+      <button
+        onClick={onRefresh}
+        className="rounded-md p-1 text-secondary hover:bg-surface-3"
+        title="Refresh"
+      >
+        <RefreshIcon />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract `TreeRow`, `DirectoryIndicator`, and `PanelHeader` into shared `FileTree/TreePrimitives.tsx` so both the diff and browse file browsers reuse identical row styling, directory indicators, and panel headers
- Refactor `BrowseFileListPanel`, `DiffFileList`, and `DiffFileListPanel` to consume the shared primitives
- Net result: visual duplication eliminated, styling changes now happen in one place

## Test plan
- [ ] Toggle to **Browse mode**: expand/collapse directories, click files to open — appearance and behavior unchanged
- [ ] Toggle to **Diff mode**: verify unified tree renders with 2-column status indicators, expand/collapse paths, click files to scroll to diff
- [ ] Verify discard/unstage hover buttons still work in diff mode
- [ ] Verify context menu works in both modes
- [ ] Verify selection highlighting works in both modes
- [ ] Verify gitignored file opacity in browse mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)