### PR TITLE
feat: refresh open file contents on external changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amend",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amend",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "dependencies": {
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/hooks/useFileBrowserState.ts
+++ b/src/hooks/useFileBrowserState.ts
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from 'react';
 import { useFileStore } from '@/stores/fileStore';
 import {
   readDirectory,
+  readFile,
   writeFile,
   startWatchingDirectory,
   stopWatchingDirectory,
@@ -24,6 +25,7 @@ export function useFileBrowserState() {
     closeBrowseFile,
     updateBrowseFileContent,
     markBrowseFileSaved,
+    refreshBrowseFileContent,
   } = useFileStore();
 
   const [entries, setEntries] = useState<FileEntry[]>([]);
@@ -65,6 +67,23 @@ export function useFileBrowserState() {
     let unlisten: (() => void) | undefined;
     onFsChanged(() => {
       window.dispatchEvent(new Event('file-tree-refresh'));
+
+      // Cancel all pending auto-save timers to prevent stale content from being written back
+      autoSaveTimers.current.forEach((timer) => clearTimeout(timer));
+      autoSaveTimers.current.clear();
+
+      // Re-read each open non-image file's content from disk
+      const openFiles = useFileStore.getState().browseOpenFiles;
+      for (const file of openFiles) {
+        if (file.isImage) continue;
+        readFile(file.path)
+          .then((content) => {
+            refreshBrowseFileContent(file.path, content);
+          })
+          .catch((err) => {
+            console.error(`[FileWatcher] Failed to re-read ${file.path}:`, err);
+          });
+      }
     }).then((fn) => {
       unlisten = fn;
     });

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -43,6 +43,10 @@ function tabMarkSaved(files: OpenFile[], path: string): OpenFile[] {
   return files.map((f) => (f.path === path ? { ...f, isDirty: false } : f));
 }
 
+function tabRefreshContent(files: OpenFile[], path: string, content: string): OpenFile[] {
+  return files.map((f) => (f.path === path ? { ...f, content, isDirty: false } : f));
+}
+
 function tabOpenAtLine(
   files: OpenFile[],
   file: OpenFile,
@@ -84,6 +88,7 @@ interface FileState {
   closeBrowseFile: (path: string) => void;
   updateBrowseFileContent: (path: string, content: string) => void;
   markBrowseFileSaved: (path: string) => void;
+  refreshBrowseFileContent: (path: string, content: string) => void;
   // Line navigation (for go-to-definition)
   pendingScrollToLine: number | null;
   pendingScrollToFile: string | null;
@@ -164,6 +169,9 @@ export const useFileStore = create<FileState>()(
       },
       markBrowseFileSaved: (path: string) => {
         set({ browseOpenFiles: tabMarkSaved(get().browseOpenFiles, path) });
+      },
+      refreshBrowseFileContent: (path: string, content: string) => {
+        set({ browseOpenFiles: tabRefreshContent(get().browseOpenFiles, path, content) });
       },
       // Line navigation (for go-to-definition)
       pendingScrollToLine: null,


### PR DESCRIPTION
## Summary
- Adds `refreshBrowseFileContent` store action to update file content and clear dirty state in one operation
- On `fs-changed` events, cancels pending auto-save timers and re-reads all open non-image files from disk
- Editor automatically updates via existing `FileContentPanel` effect since `isDirty` is cleared

## Test plan
- [ ] Open a file in the editor, modify it from a terminal — editor should show updated content immediately
- [ ] Open a file, make edits (dirty), modify externally — unsaved changes should be discarded and replaced
- [ ] Verify no auto-save writes stale content back after an external change

🤖 Generated with [Claude Code](https://claude.com/claude-code)