### PR TITLE
fix: make symbol indexing and references worktree-aware

### DIFF
--- a/src/components/FileBrowser/BrowseEditorTabs.tsx
+++ b/src/components/FileBrowser/BrowseEditorTabs.tsx
@@ -65,7 +65,7 @@ export const BrowseEditorTabs = forwardRef<BrowseEditorTabsHandle>(
       if (!activeFile?.path) return [];
 
       const currentFilePath = activeFile.path;
-      const projectRoot = currentDirectory || '';
+      const projectRoot = contextPath || currentDirectory || '';
 
       return [
         goToDefinitionExtension({
@@ -81,7 +81,13 @@ export const BrowseEditorTabs = forwardRef<BrowseEditorTabsHandle>(
         symbolHoverTooltip({ currentFilePath }),
         cmdHeldCursorExtension(),
       ];
-    }, [activeFile?.path, openBrowseFileAtLine, currentDirectory, showReferencesPanel]);
+    }, [
+      activeFile?.path,
+      openBrowseFileAtLine,
+      contextPath,
+      currentDirectory,
+      showReferencesPanel,
+    ]);
 
     // Consume pending scroll-to-line state
     useEffect(() => {

--- a/src/components/FileBrowser/ReferencesPanel.tsx
+++ b/src/components/FileBrowser/ReferencesPanel.tsx
@@ -12,17 +12,23 @@ interface ReferencesByFile {
 }
 
 export function ReferencesPanel() {
-  const { referencesSymbol, hideReferencesPanel, currentDirectory, openBrowseFileAtLine } =
-    useFileStore();
+  const {
+    referencesSymbol,
+    hideReferencesPanel,
+    contextPath,
+    currentDirectory,
+    openBrowseFileAtLine,
+  } = useFileStore();
   const [results, setResults] = useState<ReferencesByFile[]>([]);
   const [loading, setLoading] = useState(true);
   const [totalCount, setTotalCount] = useState(0);
 
   useEffect(() => {
-    if (!referencesSymbol || !currentDirectory) return;
+    const rootPath = contextPath || currentDirectory;
+    if (!referencesSymbol || !rootPath) return;
 
     setLoading(true);
-    findReferences(referencesSymbol, currentDirectory)
+    findReferences(referencesSymbol, rootPath)
       .then((refs) => {
         setTotalCount(refs.length);
 
@@ -36,8 +42,8 @@ export function ReferencesPanel() {
 
         const grouped: ReferencesByFile[] = [];
         for (const [filePath, fileRefs] of byFile) {
-          const relativePath = filePath.startsWith(currentDirectory)
-            ? filePath.slice(currentDirectory.length + 1)
+          const relativePath = filePath.startsWith(rootPath)
+            ? filePath.slice(rootPath.length + 1)
             : filePath;
           grouped.push({ filePath, relativePath, refs: fileRefs });
         }
@@ -52,7 +58,7 @@ export function ReferencesPanel() {
         setTotalCount(0);
       })
       .finally(() => setLoading(false));
-  }, [referencesSymbol, currentDirectory]);
+  }, [referencesSymbol, contextPath, currentDirectory]);
 
   if (!referencesSymbol) return null;
 

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -88,16 +88,16 @@ export function MainLayout() {
     }
   }, [currentDirectory, projects.length, addProject]);
 
-  // Index project for symbol navigation when directory changes (deferred to avoid blocking startup)
+  // Index project for symbol navigation when context path changes (deferred to avoid blocking startup)
   useEffect(() => {
-    if (!currentDirectory) return;
+    if (!contextPath) return;
     const timer = setTimeout(() => {
-      indexProject(currentDirectory).catch((err) => {
+      indexProject(contextPath).catch((err) => {
         console.error('[MainLayout] Failed to index project for symbol navigation:', err);
       });
     }, 2000);
     return () => clearTimeout(timer);
-  }, [currentDirectory]);
+  }, [contextPath]);
 
   // Sync active terminal's worktree and project to global state
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Uses `contextPath` consistently for symbol index and references requests
- Re-indexes when active tab context switches to another worktree
- Ensures references panel resolves files relative to active context

### Changes
- **MainLayout**: Index `contextPath` instead of `currentDirectory`, re-index on worktree switch
- **BrowseEditorTabs**: Pass `contextPath` as `projectRoot` to go-to-definition and `@/` alias resolution
- **ReferencesPanel**: Search references and compute relative paths using `contextPath`

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)