### PR TITLE
fix: add cancellation/versioning to diff loading queues

### DIFF
--- a/src/hooks/useBranchDiff.ts
+++ b/src/hooks/useBranchDiff.ts
@@ -24,9 +24,15 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
   const queueRef = useRef<string[]>([]);
   const activeCountRef = useRef(0);
   const mergeBaseRef = useRef<string | null>(null);
+  const generationRef = useRef(0);
 
   const processQueue = useCallback(async () => {
+    const generation = generationRef.current;
+
     while (queueRef.current.length > 0 && activeCountRef.current < CONCURRENCY_LIMIT) {
+      // Bail if generation changed (context/baseRef switch happened)
+      if (generationRef.current !== generation) return;
+
       const filePath = queueRef.current.shift();
       const mb = mergeBaseRef.current;
       if (!filePath || !repoPath || !mb) continue;
@@ -49,6 +55,10 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
 
       try {
         const diff: GitDiff = await getBranchFileDiff(repoPath, mb, filePath);
+
+        // Discard result if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
         loadedRef.current.add(filePath);
         setDiffs((prev) => {
           const next = new Map(prev);
@@ -62,6 +72,9 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
           return next;
         });
       } catch (err) {
+        // Discard error if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
         setDiffs((prev) => {
           const next = new Map(prev);
           next.set(filePath, {
@@ -76,12 +89,17 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
       } finally {
         loadingRef.current.delete(filePath);
         activeCountRef.current--;
-        processQueue();
+        // Continue processing queue only if still current generation
+        if (generationRef.current === generation) {
+          processQueue();
+        }
       }
     }
   }, [repoPath]);
 
   const clearDiffs = useCallback(() => {
+    // Bump generation to invalidate all in-flight requests
+    generationRef.current++;
     setDiffs(new Map());
     setFiles([]);
     setDiffStats(null);
@@ -97,6 +115,10 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
   const load = useCallback(async () => {
     if (!repoPath || !baseRef) return;
 
+    // Bump generation to invalidate any in-flight requests from previous load
+    generationRef.current++;
+    const generation = generationRef.current;
+
     // Clear previous state
     setDiffs(new Map());
     loadingRef.current.clear();
@@ -109,6 +131,10 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
 
     try {
       const summary = await getBranchDiffFiles(repoPath, baseRef);
+
+      // Discard result if generation changed while awaiting
+      if (generationRef.current !== generation) return;
+
       setFiles(summary.files);
       setDiffStats(summary.diffStats);
       setMergeBase(summary.mergeBase);
@@ -120,9 +146,14 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
       }
       processQueue();
     } catch (err) {
+      // Discard error if generation changed while awaiting
+      if (generationRef.current !== generation) return;
+
       setError(err instanceof Error ? err.message : 'Failed to load branch diff');
     } finally {
-      setIsLoading(false);
+      if (generationRef.current === generation) {
+        setIsLoading(false);
+      }
     }
   }, [repoPath, baseRef, processQueue]);
 

--- a/src/hooks/useMultiFileDiff.ts
+++ b/src/hooks/useMultiFileDiff.ts
@@ -13,6 +13,7 @@ const CONCURRENCY_LIMIT = 15;
 
 /**
  * Hook for loading file diffs with concurrency control.
+ * Uses a generation ID to discard stale responses after context changes.
  */
 export function useMultiFileDiff(repoPath: string | null) {
   const [diffs, setDiffs] = useState<Map<string, FileDiffData>>(new Map());
@@ -20,9 +21,15 @@ export function useMultiFileDiff(repoPath: string | null) {
   const loadedRef = useRef<Set<string>>(new Set());
   const queueRef = useRef<string[]>([]);
   const activeCountRef = useRef(0);
+  const generationRef = useRef(0);
 
   const processQueue = useCallback(async () => {
+    const generation = generationRef.current;
+
     while (queueRef.current.length > 0 && activeCountRef.current < CONCURRENCY_LIMIT) {
+      // Bail if generation changed (context switch happened)
+      if (generationRef.current !== generation) return;
+
       const filePath = queueRef.current.shift();
       if (!filePath || !repoPath) continue;
       if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) continue;
@@ -45,6 +52,10 @@ export function useMultiFileDiff(repoPath: string | null) {
 
       try {
         const diff: GitDiff = await getFileDiff(repoPath, filePath);
+
+        // Discard result if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
         loadedRef.current.add(filePath);
         setDiffs((prev) => {
           const newDiffs = new Map(prev);
@@ -58,6 +69,9 @@ export function useMultiFileDiff(repoPath: string | null) {
           return newDiffs;
         });
       } catch (err) {
+        // Discard error if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
         setDiffs((prev) => {
           const newDiffs = new Map(prev);
           newDiffs.set(filePath, {
@@ -72,8 +86,10 @@ export function useMultiFileDiff(repoPath: string | null) {
       } finally {
         loadingRef.current.delete(filePath);
         activeCountRef.current--;
-        // Continue processing queue
-        processQueue();
+        // Continue processing queue only if still current generation
+        if (generationRef.current === generation) {
+          processQueue();
+        }
       }
     }
   }, [repoPath]);
@@ -100,6 +116,8 @@ export function useMultiFileDiff(repoPath: string | null) {
   );
 
   const clearDiffs = useCallback(() => {
+    // Bump generation to invalidate all in-flight requests
+    generationRef.current++;
     setDiffs(new Map());
     loadingRef.current.clear();
     loadedRef.current.clear();


### PR DESCRIPTION
## Summary
- Introduces generation IDs (`generationRef`) in both `useMultiFileDiff` and `useBranchDiff` hooks
- Every `clearDiffs()` and `load()` call bumps the generation counter, invalidating all in-flight requests
- Async responses (both success and error) check the current generation before applying state updates — stale responses are silently discarded
- Queue processing also checks generation at each iteration, preventing further work on behalf of a cancelled generation

## Details
The core problem was that `getFileDiff`, `getBranchFileDiff`, and `getBranchDiffFiles` are async Tauri commands. When users rapidly switch `contextPath`, `diffMode`, or `baseRef`, previously-dispatched requests could resolve *after* new context was established, overwriting the current state with stale content.

The fix uses a monotonically incrementing generation counter (via `useRef`). Each generation is captured at the start of `processQueue` and `load`, and checked after every `await`. If the generation has changed, the response is discarded.

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)