### PR TITLE
fix: enforce frontend lint in CI and fix violations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Lint
+        run: npm run lint
+
       - name: TypeScript check
         run: npm run build -- --mode development
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,7 +12,7 @@ export default tseslint.config(
     rules: {
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': 'warn',
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', caughtErrorsIgnorePattern: '^_' }],
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amend",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amend",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-css": "^6.3.1",

--- a/src/hooks/useTerminal.ts
+++ b/src/hooks/useTerminal.ts
@@ -103,7 +103,7 @@ export function useTerminal(containerId: string | null) {
           // Keep the same scroll offset from the top
           terminal.scrollToLine(viewport.viewportY);
         }
-      } catch (e) {
+      } catch (_e) {
         // Renderer may not be ready yet, ignore
       }
     }

--- a/src/lib/symbolNavigation.ts
+++ b/src/lib/symbolNavigation.ts
@@ -191,7 +191,7 @@ export function findDefinitionInFile(view: EditorView, symbolName: string): Loca
       if (DEFINITION_CONTEXT_TYPES.has(node.name) || DEFINITION_TYPES.has(node.name)) {
         // Look for identifiers within this definition
         const innerTree = node.node;
-        let cursor = innerTree.cursor();
+        const cursor = innerTree.cursor();
         let depth = 0;
         const maxDepth = 5; // Don't go too deep
 
@@ -300,7 +300,7 @@ export function getImportPathAtPosition(
   pos: number
 ): { path: string; from: number; to: number } | null {
   const tree = syntaxTree(view.state);
-  let node: SyntaxNode | null = tree.resolveInner(pos, 0);
+  const node: SyntaxNode | null = tree.resolveInner(pos, 0);
 
   // Walk up to find a String node
   let stringNode: SyntaxNode | null = null;


### PR DESCRIPTION
## Summary
- Added `npm run lint` step to CI `lint-and-typecheck` job
- Fixed all 3 existing lint errors:
  - `useTerminal.ts`: unused catch parameter `e` -> `_e`
  - `symbolNavigation.ts`: two `let` variables that are never reassigned -> `const`
- Added `caughtErrorsIgnorePattern: '^_'` to ESLint `no-unused-vars` rule for consistent underscore-prefix convention
- Warning policy: errors fail CI, warnings are allowed (6 existing `react-hooks/exhaustive-deps` warnings remain as-is)

Closes #20

## Test plan
- [x] `npm run lint` exits 0 (0 errors, 6 warnings)
- [x] `npx tsc --noEmit` passes
- [x] `npx prettier --check "src/**/*.{ts,tsx,css}"` passes
- [ ] CI `lint-and-typecheck` job passes with new lint step

🤖 Generated with [Claude Code](https://claude.com/claude-code)