### PR TITLE
feat: split frontend bundle using dynamic imports and manual chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "amend",
-  "version": "0.1.19",
+  "version": "0.1.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "amend",
-      "version": "0.1.19",
+      "version": "0.1.21",
       "dependencies": {
         "@codemirror/commands": "^6.10.1",
         "@codemirror/lang-css": "^6.3.1",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:desktop": "tauri dev",
     "build": "tsc && vite build",
+    "bundle-report": "vite build && echo '--- Bundle Sizes ---' && ls -lhS dist/assets/*.js dist/assets/*.css",
     "preview": "vite preview",
     "tauri": "tauri",
     "lint": "eslint src --ext .ts,.tsx",

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useCallback, useState, useRef } from 'react';
+import { useEffect, useCallback, useState, useRef, lazy, Suspense } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useUIStore } from '@/stores/uiStore';
 import { useTerminalStore } from '@/stores/terminalStore';
@@ -8,14 +8,8 @@ import { useCloseTerminal } from '@/hooks/useTerminal';
 import { useGitPolling } from '@/hooks/useGit';
 import { useTheme } from '@/hooks/useTheme';
 import { TerminalTabs, TerminalTabsHandle } from '@/components/Terminal/TerminalTabs';
-import { DiffContentPanel } from '@/components/DiffViewer/DiffContentPanel';
-import { DiffFileListPanel } from '@/components/DiffViewer/DiffFileListPanel';
 import { DiffViewerProvider } from '@/components/DiffViewer/DiffViewerContext';
-import {
-  BrowseEditorTabs,
-  BrowseEditorTabsHandle,
-} from '@/components/FileBrowser/BrowseEditorTabs';
-import { BrowseFileListPanel } from '@/components/FileBrowser/BrowseFileListPanel';
+import type { BrowseEditorTabsHandle } from '@/components/FileBrowser/BrowseEditorTabs';
 import { GlobalSearch } from '@/components/GlobalSearch/GlobalSearch';
 import { ModalOverlay } from '@/components/ModalOverlay';
 import { indexProject, copyEntry, moveEntry, getClipboardFilePaths } from '@/lib/tauri';
@@ -31,8 +25,31 @@ import {
   SidebarIcon,
   NotesIcon,
 } from '@/components/Icons';
-import { NotesPanel } from '@/components/NotesPanel';
 import { useNotesStore } from '@/stores/notesStore';
+
+const DiffContentPanel = lazy(() =>
+  import('@/components/DiffViewer/DiffContentPanel').then((m) => ({
+    default: m.DiffContentPanel,
+  }))
+);
+const DiffFileListPanel = lazy(() =>
+  import('@/components/DiffViewer/DiffFileListPanel').then((m) => ({
+    default: m.DiffFileListPanel,
+  }))
+);
+const BrowseEditorTabs = lazy(() =>
+  import('@/components/FileBrowser/BrowseEditorTabs').then((m) => ({
+    default: m.BrowseEditorTabs,
+  }))
+);
+const BrowseFileListPanel = lazy(() =>
+  import('@/components/FileBrowser/BrowseFileListPanel').then((m) => ({
+    default: m.BrowseFileListPanel,
+  }))
+);
+const NotesPanel = lazy(() =>
+  import('@/components/NotesPanel').then((m) => ({ default: m.NotesPanel }))
+);
 
 function ThemeToggle() {
   const { themeMode, cycleTheme } = useTheme();
@@ -382,13 +399,17 @@ export function MainLayout() {
             {panelMode === 'diff' && <PanelResizeHandle />}
             {panelMode === 'diff' && (
               <Panel id="diff-content" order={2} defaultSize={40} minSize={20}>
-                <DiffContentPanel />
+                <Suspense fallback={null}>
+                  <DiffContentPanel />
+                </Suspense>
               </Panel>
             )}
             {panelMode === 'diff' && diffFileListVisible && <PanelResizeHandle />}
             {panelMode === 'diff' && diffFileListVisible && (
               <Panel id="diff-file-list" order={3} defaultSize={20} minSize={10} maxSize={40}>
-                <DiffFileListPanel />
+                <Suspense fallback={null}>
+                  <DiffFileListPanel />
+                </Suspense>
               </Panel>
             )}
 
@@ -396,7 +417,9 @@ export function MainLayout() {
             {panelMode === 'browse' && <PanelResizeHandle />}
             {panelMode === 'browse' && browseOpenFiles.length > 0 && (
               <Panel id="browse-editor" order={2} defaultSize={40} minSize={20}>
-                <BrowseEditorTabs ref={browseEditorTabsRef} />
+                <Suspense fallback={null}>
+                  <BrowseEditorTabs ref={browseEditorTabsRef} />
+                </Suspense>
               </Panel>
             )}
             {panelMode === 'browse' && browseOpenFiles.length > 0 && browseFileListVisible && (
@@ -404,7 +427,9 @@ export function MainLayout() {
             )}
             {panelMode === 'browse' && browseFileListVisible && (
               <Panel id="browse-file-list" order={3} defaultSize={20} minSize={10} maxSize={40}>
-                <BrowseFileListPanel />
+                <Suspense fallback={null}>
+                  <BrowseFileListPanel />
+                </Suspense>
               </Panel>
             )}
           </PanelGroup>
@@ -497,7 +522,9 @@ export function MainLayout() {
       )}
 
       {/* Floating Notes Panel */}
-      <NotesPanel />
+      <Suspense fallback={null}>
+        <NotesPanel />
+      </Suspense>
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,40 @@ export default defineConfig(async () => ({
     },
   },
   clearScreen: false,
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom'],
+          codemirror: [
+            '@codemirror/commands',
+            '@codemirror/lang-css',
+            '@codemirror/lang-html',
+            '@codemirror/lang-java',
+            '@codemirror/lang-javascript',
+            '@codemirror/lang-json',
+            '@codemirror/lang-markdown',
+            '@codemirror/lang-python',
+            '@codemirror/lang-rust',
+            '@codemirror/language',
+            '@codemirror/legacy-modes/mode/clike',
+            '@codemirror/search',
+            '@codemirror/state',
+            '@codemirror/view',
+            '@lezer/highlight',
+          ],
+          xterm: [
+            '@xterm/xterm',
+            '@xterm/addon-fit',
+            '@xterm/addon-web-links',
+            '@xterm/addon-webgl',
+          ],
+          highlightjs: ['highlight.js'],
+          diff: ['diff'],
+        },
+      },
+    },
+  },
   server: {
     port: 1420,
     strictPort: true,


### PR DESCRIPTION
## Summary
- Configures Vite/Rollup `manualChunks` for stable chunking of heavy dependencies (codemirror, xterm, highlight.js, diff, react)
- Adds `React.lazy` + `Suspense` for conditionally-rendered panels (diff viewer, file browser, notes) to defer loading until needed
- Adds `bundle-report` npm script for easy bundle size inspection
- Main entry chunk reduced from **1,622 KB to 353 KB (78% reduction)**

### Bundle breakdown (after)
| Chunk | Size | Gzip |
|-------|------|------|
| `index.js` (main entry) | 353 KB | 109 KB |
| `codemirror.js` | 725 KB | 258 KB |
| `xterm.js` | 394 KB | 99 KB |
| `BrowseFileListPanel.js` | 57 KB | 20 KB |
| `highlightjs.js` | 21 KB | 8 KB |
| `BrowseEditorTabs.js` | 20 KB | 7 KB |
| `DiffContentPanel.js` | 17 KB | 5 KB |
| `react-vendor.js` | 11 KB | 4 KB |
| Other lazy chunks | <10 KB each | - |

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)