### PR TITLE
feat: standardize backend I/O and add cancellable search

### DIFF
--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -5,6 +5,8 @@ use ignore::WalkBuilder;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::task::spawn_blocking;
 
@@ -16,9 +18,31 @@ pub enum FileSystemError {
     NotFound(String),
     #[error("Invalid path: {0}")]
     InvalidPath(String),
+    #[error("Search cancelled")]
+    SearchCancelled,
 }
 
 impl_serialize_as_string!(FileSystemError);
+
+/// Tracks the latest search generation so stale searches abort early.
+#[derive(Clone)]
+pub struct SearchGeneration(Arc<AtomicU64>);
+
+impl SearchGeneration {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicU64::new(0)))
+    }
+
+    /// Increment and return the new generation ID.
+    fn next(&self) -> u64 {
+        self.0.fetch_add(1, Ordering::SeqCst) + 1
+    }
+
+    /// Return the current generation ID.
+    fn current(&self) -> u64 {
+        self.0.load(Ordering::SeqCst)
+    }
+}
 
 /// Validate that a path is absolute and contains no `..` components.
 fn validate_path(path: &str) -> Result<PathBuf, FileSystemError> {
@@ -150,6 +174,8 @@ impl FileSystemManager {
         root_path: &str,
         query: &str,
         search_content: bool,
+        generation: &SearchGeneration,
+        my_gen: u64,
     ) -> Result<Vec<SearchResult>, FileSystemError> {
         let path = Path::new(root_path);
         if !path.exists() {
@@ -167,6 +193,11 @@ impl FileSystemManager {
             .build();
 
         for entry in walker.flatten() {
+            // Abort early if a newer search has been issued
+            if generation.current() != my_gen {
+                return Err(FileSystemError::SearchCancelled);
+            }
+
             if filename_matches.len() + content_matches.len() >= MAX_RESULTS {
                 break;
             }
@@ -335,126 +366,156 @@ pub async fn read_directories(
 }
 
 #[tauri::command]
-pub fn read_file(
+pub async fn read_file(
     state: tauri::State<'_, FileSystemManager>,
     path: String,
 ) -> Result<String, FileSystemError> {
-    state.read_file(&path)
-}
-
-#[tauri::command]
-pub fn read_file_base64(
-    state: tauri::State<'_, FileSystemManager>,
-    path: String,
-) -> Result<String, FileSystemError> {
-    state.read_file_base64(&path)
-}
-
-#[tauri::command]
-pub fn write_file(
-    state: tauri::State<'_, FileSystemManager>,
-    path: String,
-    contents: String,
-) -> Result<(), FileSystemError> {
-    state.write_file(&path, &contents)
-}
-
-#[tauri::command]
-pub async fn search_files(
-    state: tauri::State<'_, FileSystemManager>,
-    root_path: String,
-    query: String,
-    search_content: bool,
-) -> Result<Vec<SearchResult>, FileSystemError> {
     let mgr = state.inner().clone();
-    spawn_blocking(move || mgr.search_files(&root_path, &query, search_content))
+    spawn_blocking(move || mgr.read_file(&path)).await.unwrap()
+}
+
+#[tauri::command]
+pub async fn read_file_base64(
+    state: tauri::State<'_, FileSystemManager>,
+    path: String,
+) -> Result<String, FileSystemError> {
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.read_file_base64(&path))
         .await
         .unwrap()
 }
 
 #[tauri::command]
-pub fn rename_entry(
+pub async fn write_file(
+    state: tauri::State<'_, FileSystemManager>,
+    path: String,
+    contents: String,
+) -> Result<(), FileSystemError> {
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.write_file(&path, &contents))
+        .await
+        .unwrap()
+}
+
+#[tauri::command]
+pub async fn search_files(
+    state: tauri::State<'_, FileSystemManager>,
+    generation: tauri::State<'_, SearchGeneration>,
+    root_path: String,
+    query: String,
+    search_content: bool,
+) -> Result<Vec<SearchResult>, FileSystemError> {
+    let mgr = state.inner().clone();
+    let gen = generation.inner().clone();
+    let my_gen = gen.next();
+    spawn_blocking(move || mgr.search_files(&root_path, &query, search_content, &gen, my_gen))
+        .await
+        .unwrap()
+}
+
+#[tauri::command]
+pub async fn rename_entry(
     state: tauri::State<'_, FileSystemManager>,
     old_path: String,
     new_path: String,
 ) -> Result<(), FileSystemError> {
-    state.rename_entry(&old_path, &new_path)
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.rename_entry(&old_path, &new_path))
+        .await
+        .unwrap()
 }
 
 #[tauri::command]
-pub fn delete_file(
+pub async fn delete_file(
     state: tauri::State<'_, FileSystemManager>,
     path: String,
 ) -> Result<(), FileSystemError> {
-    state.delete_file(&path)
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.delete_file(&path))
+        .await
+        .unwrap()
 }
 
 #[tauri::command]
-pub fn delete_directory(
+pub async fn delete_directory(
     state: tauri::State<'_, FileSystemManager>,
     path: String,
 ) -> Result<(), FileSystemError> {
-    state.delete_directory(&path)
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.delete_directory(&path))
+        .await
+        .unwrap()
 }
 
 #[tauri::command]
-pub fn reveal_in_file_manager(path: String) -> Result<(), FileSystemError> {
-    let p = Path::new(&path);
-    if !p.exists() {
-        return Err(FileSystemError::NotFound(path.clone()));
-    }
+pub async fn reveal_in_file_manager(path: String) -> Result<(), FileSystemError> {
+    spawn_blocking(move || {
+        let p = Path::new(&path);
+        if !p.exists() {
+            return Err(FileSystemError::NotFound(path.clone()));
+        }
 
-    #[cfg(target_os = "macos")]
-    {
-        std::process::Command::new("open")
-            .args(["-R", &path])
-            .spawn()
-            .map_err(FileSystemError::Io)?;
-    }
+        #[cfg(target_os = "macos")]
+        {
+            std::process::Command::new("open")
+                .args(["-R", &path])
+                .spawn()
+                .map_err(FileSystemError::Io)?;
+        }
 
-    #[cfg(target_os = "windows")]
-    {
-        std::process::Command::new("explorer")
-            .args(["/select,", &path])
-            .spawn()
-            .map_err(FileSystemError::Io)?;
-    }
+        #[cfg(target_os = "windows")]
+        {
+            std::process::Command::new("explorer")
+                .args(["/select,", &path])
+                .spawn()
+                .map_err(FileSystemError::Io)?;
+        }
 
-    #[cfg(target_os = "linux")]
-    {
-        let parent = p.parent().unwrap_or(p);
-        std::process::Command::new("xdg-open")
-            .arg(parent)
-            .spawn()
-            .map_err(FileSystemError::Io)?;
-    }
+        #[cfg(target_os = "linux")]
+        {
+            let parent = p.parent().unwrap_or(p);
+            std::process::Command::new("xdg-open")
+                .arg(parent)
+                .spawn()
+                .map_err(FileSystemError::Io)?;
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
 
 #[tauri::command]
-pub fn copy_entry(
+pub async fn copy_entry(
     state: tauri::State<'_, FileSystemManager>,
     src: String,
     dest: String,
 ) -> Result<(), FileSystemError> {
-    state.copy_entry(&src, &dest)
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.copy_entry(&src, &dest))
+        .await
+        .unwrap()
 }
 
 #[tauri::command]
-pub fn move_entry(
+pub async fn move_entry(
     state: tauri::State<'_, FileSystemManager>,
     src: String,
     dest: String,
 ) -> Result<(), FileSystemError> {
-    state.move_entry(&src, &dest)
+    let mgr = state.inner().clone();
+    spawn_blocking(move || mgr.move_entry(&src, &dest))
+        .await
+        .unwrap()
 }
 
 #[tauri::command]
-pub fn get_clipboard_file_paths() -> Vec<String> {
-    #[cfg(target_os = "macos")]
-    {
-        let script = r#"
+pub async fn get_clipboard_file_paths() -> Vec<String> {
+    spawn_blocking(|| {
+        #[cfg(target_os = "macos")]
+        {
+            let script = r#"
 use framework "AppKit"
 set pb to current application's NSPasteboard's generalPasteboard()
 set urls to pb's readObjectsForClasses:{current application's NSURL} options:(missing value)
@@ -468,25 +529,28 @@ end repeat
 set AppleScript's text item delimiters to linefeed
 return paths as text
 "#;
-        match std::process::Command::new("osascript")
-            .args(["-l", "AppleScript", "-e", script])
-            .output()
-        {
-            Ok(output) => {
-                let stdout = String::from_utf8_lossy(&output.stdout);
-                stdout
-                    .trim()
-                    .lines()
-                    .filter(|l| !l.is_empty())
-                    .map(|l| l.to_string())
-                    .collect()
+            match std::process::Command::new("osascript")
+                .args(["-l", "AppleScript", "-e", script])
+                .output()
+            {
+                Ok(output) => {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    stdout
+                        .trim()
+                        .lines()
+                        .filter(|l| !l.is_empty())
+                        .map(|l| l.to_string())
+                        .collect()
+                }
+                Err(_) => Vec::new(),
             }
-            Err(_) => Vec::new(),
         }
-    }
 
-    #[cfg(not(target_os = "macos"))]
-    {
-        Vec::new()
-    }
+        #[cfg(not(target_os = "macos"))]
+        {
+            Vec::new()
+        }
+    })
+    .await
+    .unwrap()
 }

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -267,8 +267,14 @@ fn get_file_diff_sync(repo_path: &str, file_path: &str) -> Result<GitDiff, GitEr
 }
 
 #[tauri::command]
-pub fn list_worktrees(repo_path: String) -> Result<Vec<GitWorktree>, GitError> {
-    let stdout = run_git_command(&repo_path, &["worktree", "list", "--porcelain"])?;
+pub async fn list_worktrees(repo_path: String) -> Result<Vec<GitWorktree>, GitError> {
+    spawn_blocking(move || list_worktrees_sync(&repo_path))
+        .await
+        .unwrap()
+}
+
+fn list_worktrees_sync(repo_path: &str) -> Result<Vec<GitWorktree>, GitError> {
+    let stdout = run_git_command(repo_path, &["worktree", "list", "--porcelain"])?;
     let mut worktrees = Vec::new();
     let mut current_path: Option<String> = None;
     let mut current_branch: Option<String> = None;
@@ -318,7 +324,7 @@ pub fn list_worktrees(repo_path: String) -> Result<Vec<GitWorktree>, GitError> {
 }
 
 #[tauri::command]
-pub fn add_worktree(
+pub async fn add_worktree(
     repo_path: String,
     worktree_path: String,
     branch: Option<String>,
@@ -332,83 +338,103 @@ pub fn add_worktree(
         validate_no_flag(nb, "new branch name")?;
     }
 
-    let mut args = vec!["worktree", "add"];
+    spawn_blocking(move || {
+        let mut args = vec!["worktree", "add"];
 
-    // Build arguments based on options
-    let new_branch_arg;
-    if let Some(ref new_branch_name) = new_branch {
-        args.push("-b");
-        new_branch_arg = new_branch_name.clone();
-        args.push(&new_branch_arg);
-    }
+        // Build arguments based on options
+        let new_branch_arg;
+        if let Some(ref new_branch_name) = new_branch {
+            args.push("-b");
+            new_branch_arg = new_branch_name.clone();
+            args.push(&new_branch_arg);
+        }
 
-    args.push(&worktree_path);
+        args.push(&worktree_path);
 
-    let branch_arg;
-    if let Some(ref branch_name) = branch {
-        branch_arg = branch_name.clone();
-        args.push(&branch_arg);
-    }
+        let branch_arg;
+        if let Some(ref branch_name) = branch {
+            branch_arg = branch_name.clone();
+            args.push(&branch_arg);
+        }
 
-    run_git_command(&repo_path, &args)?;
+        run_git_command(&repo_path, &args)?;
 
-    // Determine the branch name for the result
-    let result_branch = new_branch.or(branch).unwrap_or_else(|| "HEAD".to_string());
+        // Determine the branch name for the result
+        let result_branch = new_branch.or(branch).unwrap_or_else(|| "HEAD".to_string());
 
-    // Convert to absolute path if relative
-    let absolute_path = if Path::new(&worktree_path).is_absolute() {
-        worktree_path
-    } else {
-        Path::new(&repo_path)
-            .join(&worktree_path)
-            .to_string_lossy()
-            .to_string()
-    };
+        // Convert to absolute path if relative
+        let absolute_path = if Path::new(&worktree_path).is_absolute() {
+            worktree_path
+        } else {
+            Path::new(&repo_path)
+                .join(&worktree_path)
+                .to_string_lossy()
+                .to_string()
+        };
 
-    Ok(GitWorktree {
-        path: absolute_path,
-        branch: result_branch,
-        is_main: false,
+        Ok(GitWorktree {
+            path: absolute_path,
+            branch: result_branch,
+            is_main: false,
+        })
     })
+    .await
+    .unwrap()
 }
 
 #[tauri::command]
-pub fn remove_worktree(
+pub async fn remove_worktree(
     repo_path: String,
     worktree_path: String,
     force: bool,
 ) -> Result<(), GitError> {
-    let mut args = vec!["worktree", "remove"];
+    spawn_blocking(move || {
+        let mut args = vec!["worktree", "remove"];
 
-    if force {
-        args.push("--force");
-    }
+        if force {
+            args.push("--force");
+        }
 
-    args.push(&worktree_path);
+        args.push(&worktree_path);
 
-    run_git_command(&repo_path, &args)?;
-    Ok(())
+        run_git_command(&repo_path, &args)?;
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
 
 #[tauri::command]
-pub fn restore_file(repo_path: String, file_path: String) -> Result<(), GitError> {
+pub async fn restore_file(repo_path: String, file_path: String) -> Result<(), GitError> {
     validate_no_flag(&file_path, "file path")?;
-    run_git_command(&repo_path, &["restore", "--", &file_path])?;
-    Ok(())
+    spawn_blocking(move || {
+        run_git_command(&repo_path, &["restore", "--", &file_path])?;
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
 
 #[tauri::command]
-pub fn unstage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
+pub async fn unstage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
     validate_no_flag(&file_path, "file path")?;
-    run_git_command(&repo_path, &["restore", "--staged", "--", &file_path])?;
-    Ok(())
+    spawn_blocking(move || {
+        run_git_command(&repo_path, &["restore", "--staged", "--", &file_path])?;
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
 
 #[tauri::command]
-pub fn stage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
+pub async fn stage_file(repo_path: String, file_path: String) -> Result<(), GitError> {
     validate_no_flag(&file_path, "file path")?;
-    run_git_command(&repo_path, &["add", "--", &file_path])?;
-    Ok(())
+    spawn_blocking(move || {
+        run_git_command(&repo_path, &["add", "--", &file_path])?;
+        Ok(())
+    })
+    .await
+    .unwrap()
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -765,39 +791,43 @@ fn get_branch_file_diff_sync(
 }
 
 #[tauri::command]
-pub fn list_branches(repo_path: String) -> Result<Vec<GitBranch>, GitError> {
-    // Get local branches
-    let stdout = run_git_command(&repo_path, &["branch", "--format=%(refname:short)|%(HEAD)"])?;
+pub async fn list_branches(repo_path: String) -> Result<Vec<GitBranch>, GitError> {
+    spawn_blocking(move || {
+        // Get local branches
+        let stdout = run_git_command(&repo_path, &["branch", "--format=%(refname:short)|%(HEAD)"])?;
 
-    let mut branches: Vec<GitBranch> = stdout
-        .lines()
-        .filter(|line| !line.is_empty())
-        .map(|line| {
-            let parts: Vec<&str> = line.split('|').collect();
-            let name = parts.first().unwrap_or(&"").to_string();
-            let is_current = parts.get(1).map(|s| *s == "*").unwrap_or(false);
-            GitBranch {
-                name,
-                is_remote: false,
-                is_current,
-            }
-        })
-        .collect();
+        let mut branches: Vec<GitBranch> = stdout
+            .lines()
+            .filter(|line| !line.is_empty())
+            .map(|line| {
+                let parts: Vec<&str> = line.split('|').collect();
+                let name = parts.first().unwrap_or(&"").to_string();
+                let is_current = parts.get(1).map(|s| *s == "*").unwrap_or(false);
+                GitBranch {
+                    name,
+                    is_remote: false,
+                    is_current,
+                }
+            })
+            .collect();
 
-    // Get remote branches
-    if let Ok(remote_stdout) =
-        run_git_command(&repo_path, &["branch", "-r", "--format=%(refname:short)"])
-    {
-        for line in remote_stdout.lines() {
-            if !line.is_empty() && !line.contains("HEAD") {
-                branches.push(GitBranch {
-                    name: line.to_string(),
-                    is_remote: true,
-                    is_current: false,
-                });
+        // Get remote branches
+        if let Ok(remote_stdout) =
+            run_git_command(&repo_path, &["branch", "-r", "--format=%(refname:short)"])
+        {
+            for line in remote_stdout.lines() {
+                if !line.is_empty() && !line.contains("HEAD") {
+                    branches.push(GitBranch {
+                        name: line.to_string(),
+                        is_remote: true,
+                        is_current: false,
+                    });
+                }
             }
         }
-    }
 
-    Ok(branches)
+        Ok(branches)
+    })
+    .await
+    .unwrap()
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,10 +5,11 @@ mod symbols;
 mod terminal;
 mod watcher;
 
-use filesystem::FileSystemManager;
+use filesystem::{FileSystemManager, SearchGeneration};
 use symbols::{SymbolDefinition, SymbolIndex, SymbolReference};
 use tauri::State;
 use terminal::TerminalManager;
+use tokio::task::spawn_blocking;
 use watcher::FileWatcher;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -20,6 +21,7 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .manage(TerminalManager::new())
         .manage(FileSystemManager::new())
+        .manage(SearchGeneration::new())
         .manage(SymbolIndex::new())
         .manage(FileWatcher::new())
         .invoke_handler(tauri::generate_handler![
@@ -74,21 +76,32 @@ pub fn run() {
 #[tauri::command]
 async fn index_project(root_path: String, index: State<'_, SymbolIndex>) -> Result<(), String> {
     let idx = index.inner().clone();
-    tokio::task::spawn_blocking(move || idx.index_project(&root_path))
+    spawn_blocking(move || idx.index_project(&root_path))
         .await
         .unwrap()
 }
 
 #[tauri::command]
-fn find_definition(symbol: String, index: State<SymbolIndex>) -> Vec<SymbolDefinition> {
-    index.find_definition(&symbol)
+async fn find_definition(
+    symbol: String,
+    index: State<'_, SymbolIndex>,
+) -> Result<Vec<SymbolDefinition>, String> {
+    let idx = index.inner().clone();
+    Ok(spawn_blocking(move || idx.find_definition(&symbol))
+        .await
+        .unwrap())
 }
 
 #[tauri::command]
-fn find_references(
+async fn find_references(
     symbol: String,
     root_path: String,
-    index: State<SymbolIndex>,
-) -> Vec<SymbolReference> {
-    index.find_references(&symbol, &root_path)
+    index: State<'_, SymbolIndex>,
+) -> Result<Vec<SymbolReference>, String> {
+    let idx = index.inner().clone();
+    Ok(
+        spawn_blocking(move || idx.find_references(&symbol, &root_path))
+            .await
+            .unwrap(),
+    )
 }

--- a/src/components/GlobalSearch/GlobalSearch.tsx
+++ b/src/components/GlobalSearch/GlobalSearch.tsx
@@ -67,24 +67,42 @@ export function GlobalSearch() {
     }
   }, [isOpen]);
 
-  // Debounced search
+  // Debounced search with stale-result handling.
+  // The backend uses a generation counter so that when a new search_files call is
+  // issued, any in-flight search aborts early with "Search cancelled". We track
+  // a local generation ID so we never apply results from a stale request.
+  const searchGenRef = useRef(0);
+
   useEffect(() => {
     if (!isOpen || !query.trim() || !searchRoot) {
       setResults([]);
       return;
     }
 
+    const gen = ++searchGenRef.current;
+
     const timeoutId = setTimeout(async () => {
       setIsSearching(true);
       try {
         const searchResults = await searchFiles(searchRoot, query.trim(), true);
-        setResults(searchResults);
-        setSelectedIndex(0);
+        // Only apply results if this is still the latest search
+        if (searchGenRef.current === gen) {
+          setResults(searchResults);
+          setSelectedIndex(0);
+        }
       } catch (err) {
-        console.error('Search failed:', err);
-        setResults([]);
+        // Ignore cancellation errors from the backend (stale search)
+        const msg = String(err);
+        if (!msg.includes('Search cancelled')) {
+          console.error('Search failed:', err);
+        }
+        if (searchGenRef.current === gen) {
+          setResults([]);
+        }
       } finally {
-        setIsSearching(false);
+        if (searchGenRef.current === gen) {
+          setIsSearching(false);
+        }
       }
     }, 150);
 


### PR DESCRIPTION
## Summary
- Moves all filesystem and git Tauri command handlers to `spawn_blocking` so heavy I/O never blocks the async runtime
- Adds a generation-counter based cancellation mechanism for `search_files` so in-flight searches abort early when a newer query is issued
- Frontend `GlobalSearch` now tracks a local generation ID to discard stale results

Closes #26

## Test plan
- [ ] Verify file operations (read, write, rename, delete, copy, move) work normally
- [ ] Verify search returns results correctly and rapidly-typed queries don't show stale results
- [ ] Verify git operations (stage, unstage, restore, worktrees, branches) work normally
- [ ] Verify symbol navigation (go to definition, find references) works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)