### PR TITLE
refactor: unify duplicated diff tree builders and async queue logic

### DIFF
--- a/src/components/DiffViewer/DiffFileList.tsx
+++ b/src/components/DiffViewer/DiffFileList.tsx
@@ -6,6 +6,7 @@ import { ContextMenu } from '@/components/ContextMenu/ContextMenu';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
 import { DiscardIcon } from '@/components/Icons';
 import { TreeRow, DirectoryIndicator } from '@/components/FileTree/TreePrimitives';
+import { FileCategories, FileTreeNode, buildWorkingTree, buildBranchTree } from '@/lib/diffTree';
 
 interface DiffFileListProps {
   status: GitStatus | null;
@@ -17,127 +18,6 @@ interface DiffFileListProps {
   onSelectFile?: (path: string) => void;
   branchFiles?: GitFileStatus[];
   mode?: DiffMode;
-}
-
-interface FileCategories {
-  staged?: string;
-  unstaged?: string;
-  untracked?: boolean;
-  conflicted?: boolean;
-  branch?: string;
-}
-
-interface FileTreeNode {
-  name: string;
-  path: string;
-  isDirectory: boolean;
-  children: Map<string, FileTreeNode>;
-  categories?: FileCategories;
-}
-
-function buildUnifiedTree(status: GitStatus): FileTreeNode {
-  const root: FileTreeNode = {
-    name: '',
-    path: '',
-    isDirectory: true,
-    children: new Map(),
-  };
-
-  function ensurePath(filePath: string): FileTreeNode {
-    const parts = filePath.split('/');
-    let current = root;
-
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      const isLast = i === parts.length - 1;
-      const currentPath = parts.slice(0, i + 1).join('/');
-
-      if (!current.children.has(part)) {
-        current.children.set(part, {
-          name: part,
-          path: currentPath,
-          isDirectory: !isLast,
-          children: new Map(),
-        });
-      }
-
-      current = current.children.get(part)!;
-    }
-
-    if (!current.categories) {
-      current.categories = {};
-    }
-
-    return current;
-  }
-
-  for (const file of status.staged) {
-    const node = ensurePath(file.path);
-    node.categories!.staged = file.status;
-  }
-
-  for (const file of status.unstaged) {
-    const node = ensurePath(file.path);
-    node.categories!.unstaged = file.status;
-  }
-
-  for (const path of status.untracked) {
-    const node = ensurePath(path);
-    node.categories!.untracked = true;
-  }
-
-  if (status.conflicted) {
-    for (const path of status.conflicted) {
-      const node = ensurePath(path);
-      node.categories!.conflicted = true;
-    }
-  }
-
-  return root;
-}
-
-function buildBranchTree(files: GitFileStatus[]): FileTreeNode {
-  const root: FileTreeNode = {
-    name: '',
-    path: '',
-    isDirectory: true,
-    children: new Map(),
-  };
-
-  function ensurePath(filePath: string): FileTreeNode {
-    const parts = filePath.split('/');
-    let current = root;
-
-    for (let i = 0; i < parts.length; i++) {
-      const part = parts[i];
-      const isLast = i === parts.length - 1;
-      const currentPath = parts.slice(0, i + 1).join('/');
-
-      if (!current.children.has(part)) {
-        current.children.set(part, {
-          name: part,
-          path: currentPath,
-          isDirectory: !isLast,
-          children: new Map(),
-        });
-      }
-
-      current = current.children.get(part)!;
-    }
-
-    if (!current.categories) {
-      current.categories = {};
-    }
-
-    return current;
-  }
-
-  for (const file of files) {
-    const node = ensurePath(file.path);
-    node.categories!.branch = file.status;
-  }
-
-  return root;
 }
 
 const STATUS_LETTERS: Record<string, string> = {
@@ -375,7 +255,7 @@ export function DiffFileList({
       return buildBranchTree(branchFiles);
     }
     if (!status) return null;
-    return buildUnifiedTree(status);
+    return buildWorkingTree(status);
   }, [status, branchFiles, mode]);
 
   if (isLoading) {

--- a/src/hooks/useBranchDiff.ts
+++ b/src/hooks/useBranchDiff.ts
@@ -1,130 +1,46 @@
 import { useState, useCallback, useRef, useEffect } from 'react';
-import {
-  getBranchDiffFiles,
-  getBranchFileDiff,
-  GitFileStatus,
-  DiffStats,
-  GitDiff,
-} from '@/lib/tauri';
-import { FileDiffData } from '@/hooks/useMultiFileDiff';
-
-const CONCURRENCY_LIMIT = 15;
+import { getBranchDiffFiles, getBranchFileDiff, GitFileStatus, DiffStats } from '@/lib/tauri';
+import { useDiffQueue } from '@/hooks/useDiffQueue';
 
 export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
   const [files, setFiles] = useState<GitFileStatus[]>([]);
   const [diffStats, setDiffStats] = useState<DiffStats | null>(null);
   const [mergeBase, setMergeBase] = useState<string | null>(null);
-  const [diffs, setDiffs] = useState<Map<string, FileDiffData>>(new Map());
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Concurrency queue refs
-  const loadingRef = useRef<Set<string>>(new Set());
-  const loadedRef = useRef<Set<string>>(new Set());
-  const queueRef = useRef<string[]>([]);
-  const activeCountRef = useRef(0);
   const mergeBaseRef = useRef<string | null>(null);
-  const generationRef = useRef(0);
+  const loadGenerationRef = useRef(0);
 
-  const processQueue = useCallback(async () => {
-    const generation = generationRef.current;
-
-    while (queueRef.current.length > 0 && activeCountRef.current < CONCURRENCY_LIMIT) {
-      // Bail if generation changed (context/baseRef switch happened)
-      if (generationRef.current !== generation) return;
-
-      const filePath = queueRef.current.shift();
+  const fetchDiff = useCallback(
+    (filePath: string) => {
       const mb = mergeBaseRef.current;
-      if (!filePath || !repoPath || !mb) continue;
-      if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) continue;
+      if (!repoPath || !mb) return Promise.reject(new Error('No repo path or merge base'));
+      return getBranchFileDiff(repoPath, mb, filePath);
+    },
+    [repoPath]
+  );
 
-      activeCountRef.current++;
-      loadingRef.current.add(filePath);
-
-      setDiffs((prev) => {
-        const next = new Map(prev);
-        next.set(filePath, {
-          oldContent: '',
-          newContent: '',
-          isBinary: false,
-          isLoading: true,
-          error: null,
-        });
-        return next;
-      });
-
-      try {
-        const diff: GitDiff = await getBranchFileDiff(repoPath, mb, filePath);
-
-        // Discard result if generation changed while awaiting
-        if (generationRef.current !== generation) return;
-
-        loadedRef.current.add(filePath);
-        setDiffs((prev) => {
-          const next = new Map(prev);
-          next.set(filePath, {
-            oldContent: diff.oldContent,
-            newContent: diff.newContent,
-            isBinary: diff.isBinary,
-            isLoading: false,
-            error: null,
-          });
-          return next;
-        });
-      } catch (err) {
-        // Discard error if generation changed while awaiting
-        if (generationRef.current !== generation) return;
-
-        setDiffs((prev) => {
-          const next = new Map(prev);
-          next.set(filePath, {
-            oldContent: '',
-            newContent: '',
-            isBinary: false,
-            isLoading: false,
-            error: err instanceof Error ? err.message : 'Failed to load diff',
-          });
-          return next;
-        });
-      } finally {
-        loadingRef.current.delete(filePath);
-        activeCountRef.current--;
-        // Continue processing queue only if still current generation
-        if (generationRef.current === generation) {
-          processQueue();
-        }
-      }
-    }
-  }, [repoPath]);
+  const { diffs, enqueueBatch, clear: clearQueue } = useDiffQueue(fetchDiff);
 
   const clearDiffs = useCallback(() => {
-    // Bump generation to invalidate all in-flight requests
-    generationRef.current++;
-    setDiffs(new Map());
+    clearQueue();
     setFiles([]);
     setDiffStats(null);
     setMergeBase(null);
     setError(null);
     mergeBaseRef.current = null;
-    loadingRef.current.clear();
-    loadedRef.current.clear();
-    queueRef.current = [];
-    activeCountRef.current = 0;
-  }, []);
+  }, [clearQueue]);
 
   const load = useCallback(async () => {
     if (!repoPath || !baseRef) return;
 
     // Bump generation to invalidate any in-flight requests from previous load
-    generationRef.current++;
-    const generation = generationRef.current;
+    loadGenerationRef.current++;
+    const generation = loadGenerationRef.current;
 
-    // Clear previous state
-    setDiffs(new Map());
-    loadingRef.current.clear();
-    loadedRef.current.clear();
-    queueRef.current = [];
-    activeCountRef.current = 0;
+    // Clear previous queue state
+    clearQueue();
 
     setIsLoading(true);
     setError(null);
@@ -133,7 +49,7 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
       const summary = await getBranchDiffFiles(repoPath, baseRef);
 
       // Discard result if generation changed while awaiting
-      if (generationRef.current !== generation) return;
+      if (loadGenerationRef.current !== generation) return;
 
       setFiles(summary.files);
       setDiffStats(summary.diffStats);
@@ -141,21 +57,18 @@ export function useBranchDiff(repoPath: string | null, baseRef: string | null) {
       mergeBaseRef.current = summary.mergeBase;
 
       // Queue all file diffs
-      for (const file of summary.files) {
-        queueRef.current.push(file.path);
-      }
-      processQueue();
+      enqueueBatch(summary.files.map((f) => f.path));
     } catch (err) {
       // Discard error if generation changed while awaiting
-      if (generationRef.current !== generation) return;
+      if (loadGenerationRef.current !== generation) return;
 
       setError(err instanceof Error ? err.message : 'Failed to load branch diff');
     } finally {
-      if (generationRef.current === generation) {
+      if (loadGenerationRef.current === generation) {
         setIsLoading(false);
       }
     }
-  }, [repoPath, baseRef, processQueue]);
+  }, [repoPath, baseRef, clearQueue, enqueueBatch]);
 
   // Load when repoPath or baseRef changes
   useEffect(() => {

--- a/src/hooks/useDiffQueue.ts
+++ b/src/hooks/useDiffQueue.ts
@@ -1,0 +1,145 @@
+import { useState, useCallback, useRef } from 'react';
+import { GitDiff } from '@/lib/tauri';
+
+export interface FileDiffData {
+  oldContent: string;
+  newContent: string;
+  isBinary: boolean;
+  isLoading: boolean;
+  error: string | null;
+}
+
+const CONCURRENCY_LIMIT = 15;
+
+/**
+ * Reusable bounded async queue for loading file diffs with concurrency control.
+ * Accepts a fetcher function so callers can supply different Tauri commands
+ * (working-tree diff vs branch diff). Uses a generation ID to discard stale
+ * responses after context changes.
+ */
+export function useDiffQueue(fetchDiff: (filePath: string) => Promise<GitDiff>) {
+  const [diffs, setDiffs] = useState<Map<string, FileDiffData>>(new Map());
+  const loadingRef = useRef<Set<string>>(new Set());
+  const loadedRef = useRef<Set<string>>(new Set());
+  const queueRef = useRef<string[]>([]);
+  const activeCountRef = useRef(0);
+  const generationRef = useRef(0);
+
+  const processQueue = useCallback(async () => {
+    const generation = generationRef.current;
+
+    while (queueRef.current.length > 0 && activeCountRef.current < CONCURRENCY_LIMIT) {
+      // Bail if generation changed (context switch happened)
+      if (generationRef.current !== generation) return;
+
+      const filePath = queueRef.current.shift();
+      if (!filePath) continue;
+      if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) continue;
+
+      activeCountRef.current++;
+      loadingRef.current.add(filePath);
+
+      // Set loading state
+      setDiffs((prev) => {
+        const next = new Map(prev);
+        next.set(filePath, {
+          oldContent: '',
+          newContent: '',
+          isBinary: false,
+          isLoading: true,
+          error: null,
+        });
+        return next;
+      });
+
+      try {
+        const diff: GitDiff = await fetchDiff(filePath);
+
+        // Discard result if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
+        loadedRef.current.add(filePath);
+        setDiffs((prev) => {
+          const next = new Map(prev);
+          next.set(filePath, {
+            oldContent: diff.oldContent,
+            newContent: diff.newContent,
+            isBinary: diff.isBinary,
+            isLoading: false,
+            error: null,
+          });
+          return next;
+        });
+      } catch (err) {
+        // Discard error if generation changed while awaiting
+        if (generationRef.current !== generation) return;
+
+        setDiffs((prev) => {
+          const next = new Map(prev);
+          next.set(filePath, {
+            oldContent: '',
+            newContent: '',
+            isBinary: false,
+            isLoading: false,
+            error: err instanceof Error ? err.message : 'Failed to load diff',
+          });
+          return next;
+        });
+      } finally {
+        loadingRef.current.delete(filePath);
+        activeCountRef.current--;
+        // Continue processing queue only if still current generation
+        if (generationRef.current === generation) {
+          processQueue();
+        }
+      }
+    }
+  }, [fetchDiff]);
+
+  const enqueue = useCallback(
+    (filePath: string) => {
+      // Skip if already loading or loaded
+      if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) {
+        return;
+      }
+
+      // Skip if already in queue
+      if (queueRef.current.includes(filePath)) {
+        return;
+      }
+
+      // Add to queue and process
+      queueRef.current.push(filePath);
+      processQueue();
+    },
+    [processQueue]
+  );
+
+  const enqueueBatch = useCallback(
+    (filePaths: string[]) => {
+      for (const filePath of filePaths) {
+        if (
+          !loadingRef.current.has(filePath) &&
+          !loadedRef.current.has(filePath) &&
+          !queueRef.current.includes(filePath)
+        ) {
+          queueRef.current.push(filePath);
+        }
+      }
+      processQueue();
+    },
+    [processQueue]
+  );
+
+  const clear = useCallback(() => {
+    // Bump generation to invalidate all in-flight requests
+    generationRef.current++;
+    setDiffs(new Map());
+    loadingRef.current.clear();
+    loadedRef.current.clear();
+    queueRef.current = [];
+    activeCountRef.current = 0;
+  }, []);
+
+  return { diffs, enqueue, enqueueBatch, clear, generationRef };
+}

--- a/src/hooks/useMultiFileDiff.ts
+++ b/src/hooks/useMultiFileDiff.ts
@@ -1,129 +1,29 @@
-import { useState, useCallback, useRef } from 'react';
-import { getFileDiff, GitDiff } from '@/lib/tauri';
+import { useCallback, useMemo } from 'react';
+import { getFileDiff } from '@/lib/tauri';
+import { useDiffQueue } from '@/hooks/useDiffQueue';
 
-export interface FileDiffData {
-  oldContent: string;
-  newContent: string;
-  isBinary: boolean;
-  isLoading: boolean;
-  error: string | null;
-}
-
-const CONCURRENCY_LIMIT = 15;
+// Re-export for consumers that import FileDiffData from here
+export type { FileDiffData } from '@/hooks/useDiffQueue';
 
 /**
- * Hook for loading file diffs with concurrency control.
- * Uses a generation ID to discard stale responses after context changes.
+ * Hook for loading working-tree file diffs with concurrency control.
+ * Delegates to useDiffQueue with the working-tree fetch function.
  */
 export function useMultiFileDiff(repoPath: string | null) {
-  const [diffs, setDiffs] = useState<Map<string, FileDiffData>>(new Map());
-  const loadingRef = useRef<Set<string>>(new Set());
-  const loadedRef = useRef<Set<string>>(new Set());
-  const queueRef = useRef<string[]>([]);
-  const activeCountRef = useRef(0);
-  const generationRef = useRef(0);
-
-  const processQueue = useCallback(async () => {
-    const generation = generationRef.current;
-
-    while (queueRef.current.length > 0 && activeCountRef.current < CONCURRENCY_LIMIT) {
-      // Bail if generation changed (context switch happened)
-      if (generationRef.current !== generation) return;
-
-      const filePath = queueRef.current.shift();
-      if (!filePath || !repoPath) continue;
-      if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) continue;
-
-      activeCountRef.current++;
-      loadingRef.current.add(filePath);
-
-      // Set loading state
-      setDiffs((prev) => {
-        const newDiffs = new Map(prev);
-        newDiffs.set(filePath, {
-          oldContent: '',
-          newContent: '',
-          isBinary: false,
-          isLoading: true,
-          error: null,
-        });
-        return newDiffs;
-      });
-
-      try {
-        const diff: GitDiff = await getFileDiff(repoPath, filePath);
-
-        // Discard result if generation changed while awaiting
-        if (generationRef.current !== generation) return;
-
-        loadedRef.current.add(filePath);
-        setDiffs((prev) => {
-          const newDiffs = new Map(prev);
-          newDiffs.set(filePath, {
-            oldContent: diff.oldContent,
-            newContent: diff.newContent,
-            isBinary: diff.isBinary,
-            isLoading: false,
-            error: null,
-          });
-          return newDiffs;
-        });
-      } catch (err) {
-        // Discard error if generation changed while awaiting
-        if (generationRef.current !== generation) return;
-
-        setDiffs((prev) => {
-          const newDiffs = new Map(prev);
-          newDiffs.set(filePath, {
-            oldContent: '',
-            newContent: '',
-            isBinary: false,
-            isLoading: false,
-            error: err instanceof Error ? err.message : 'Failed to load diff',
-          });
-          return newDiffs;
-        });
-      } finally {
-        loadingRef.current.delete(filePath);
-        activeCountRef.current--;
-        // Continue processing queue only if still current generation
-        if (generationRef.current === generation) {
-          processQueue();
-        }
-      }
-    }
-  }, [repoPath]);
-
-  const loadDiff = useCallback(
+  const fetchDiff = useCallback(
     (filePath: string) => {
-      if (!repoPath) return;
-
-      // Skip if already loading or loaded
-      if (loadingRef.current.has(filePath) || loadedRef.current.has(filePath)) {
-        return;
-      }
-
-      // Skip if already in queue
-      if (queueRef.current.includes(filePath)) {
-        return;
-      }
-
-      // Add to queue and process
-      queueRef.current.push(filePath);
-      processQueue();
+      if (!repoPath) return Promise.reject(new Error('No repo path'));
+      return getFileDiff(repoPath, filePath);
     },
-    [repoPath, processQueue]
+    [repoPath]
   );
 
-  const clearDiffs = useCallback(() => {
-    // Bump generation to invalidate all in-flight requests
-    generationRef.current++;
-    setDiffs(new Map());
-    loadingRef.current.clear();
-    loadedRef.current.clear();
-    queueRef.current = [];
-    activeCountRef.current = 0;
-  }, []);
+  const { diffs, enqueue, clear } = useDiffQueue(fetchDiff);
 
-  return { diffs, loadDiff, clearDiffs };
+  const loadDiff = useMemo(() => {
+    if (!repoPath) return () => {};
+    return enqueue;
+  }, [repoPath, enqueue]);
+
+  return { diffs, loadDiff, clearDiffs: clear };
 }

--- a/src/lib/diffTree.ts
+++ b/src/lib/diffTree.ts
@@ -1,0 +1,96 @@
+import { GitStatus, GitFileStatus } from '@/lib/tauri';
+
+export interface FileCategories {
+  staged?: string;
+  unstaged?: string;
+  untracked?: boolean;
+  conflicted?: boolean;
+  branch?: string;
+}
+
+export interface FileTreeNode {
+  name: string;
+  path: string;
+  isDirectory: boolean;
+  children: Map<string, FileTreeNode>;
+  categories?: FileCategories;
+}
+
+/**
+ * Low-level helper: walks a slash-delimited file path and ensures every
+ * intermediate directory node plus the final file node exist in the tree.
+ * Returns the leaf node so callers can attach category metadata.
+ */
+function ensurePath(root: FileTreeNode, filePath: string): FileTreeNode {
+  const parts = filePath.split('/');
+  let current = root;
+
+  for (let i = 0; i < parts.length; i++) {
+    const part = parts[i];
+    const isLast = i === parts.length - 1;
+    const currentPath = parts.slice(0, i + 1).join('/');
+
+    if (!current.children.has(part)) {
+      current.children.set(part, {
+        name: part,
+        path: currentPath,
+        isDirectory: !isLast,
+        children: new Map(),
+      });
+    }
+
+    current = current.children.get(part)!;
+  }
+
+  if (!current.categories) {
+    current.categories = {};
+  }
+
+  return current;
+}
+
+function createRoot(): FileTreeNode {
+  return { name: '', path: '', isDirectory: true, children: new Map() };
+}
+
+/**
+ * Build a tree from working-tree git status (staged, unstaged, untracked,
+ * conflicted categories).
+ */
+export function buildWorkingTree(status: GitStatus): FileTreeNode {
+  const root = createRoot();
+
+  for (const file of status.staged) {
+    ensurePath(root, file.path).categories!.staged = file.status;
+  }
+
+  for (const file of status.unstaged) {
+    ensurePath(root, file.path).categories!.unstaged = file.status;
+  }
+
+  for (const path of status.untracked) {
+    ensurePath(root, path).categories!.untracked = true;
+  }
+
+  if (status.conflicted) {
+    for (const path of status.conflicted) {
+      ensurePath(root, path).categories!.conflicted = true;
+    }
+  }
+
+  return root;
+}
+
+/**
+ * Build a tree from branch diff file list (all files share the "branch"
+ * category).
+ */
+export function buildBranchTree(files: GitFileStatus[]): FileTreeNode {
+  const root = createRoot();
+
+  for (const file of files) {
+    ensurePath(root, file.path).categories!.branch = file.status;
+  }
+
+  return root;
+}


### PR DESCRIPTION
## Summary
- Extracts shared `useDiffQueue` hook to eliminate duplicated bounded async queue implementations between `useMultiFileDiff` and `useBranchDiff`
- Extracts shared `diffTree` utility (`buildWorkingTree`, `buildBranchTree`) with a common `ensurePath` helper to replace duplicate tree-building functions in `DiffFileList`
- Removes ~70 lines of duplicate logic while maintaining full behavior parity

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)