### PR TITLE
refactor: replace file-tree-refresh event bus with store-driven invalidation

### DIFF
--- a/src/components/ContextMenu/FileContextMenu.tsx
+++ b/src/components/ContextMenu/FileContextMenu.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useState, useEffect, useRef } from 'react';
 import { ContextMenu, ContextMenuItem } from './ContextMenu';
-import { useContextMenuStore, dispatchFileTreeRefresh } from '@/stores/contextMenuStore';
+import { useContextMenuStore } from '@/stores/contextMenuStore';
 import { useFileStore } from '@/stores/fileStore';
 import { ModalOverlay } from '@/components/ModalOverlay';
 import { ConfirmDialog } from '@/components/ConfirmDialog';
@@ -49,7 +49,7 @@ function RenameDialog() {
 
     try {
       await renameEntry(renameTarget.path, newPath);
-      dispatchFileTreeRefresh();
+      useFileStore.getState().invalidateFileTree();
     } catch (error) {
       console.error('Failed to rename:', error);
     }
@@ -109,7 +109,7 @@ function ConfirmDeleteDialog() {
       } else {
         await deleteFile(deleteTarget.path);
       }
-      dispatchFileTreeRefresh();
+      useFileStore.getState().invalidateFileTree();
     } catch (error) {
       console.error('Failed to delete:', error);
     }
@@ -178,7 +178,7 @@ export function FileContextMenu() {
         await copyEntry(clipboard.entry.path, destPath);
       }
       clearClipboard();
-      dispatchFileTreeRefresh();
+      useFileStore.getState().invalidateFileTree();
     } catch (error) {
       console.error('Failed to paste:', error);
     }

--- a/src/components/FileBrowser/BrowseFileListPanel.tsx
+++ b/src/components/FileBrowser/BrowseFileListPanel.tsx
@@ -3,6 +3,7 @@ import { Virtuoso } from 'react-virtuoso';
 import { useFileBrowserState } from '@/hooks/useFileBrowserState';
 import { readDirectories, FileEntry } from '@/lib/tauri';
 import { useContextMenuStore } from '@/stores/contextMenuStore';
+import { useFileStore } from '@/stores/fileStore';
 import { useUIStore } from '@/stores/uiStore';
 import { getFileIconColor, sortDirectoriesFirst } from '@/lib/fileUtils';
 import { FolderIcon, FileIcon } from '@/components/Icons';
@@ -46,11 +47,13 @@ function BrowseFileList({
   const contextTargetPath = targetEntry?.path ?? null;
   const expandedDirs = useUIStore((s) => s.browseExpandedDirs);
   const toggleBrowseExpandedDir = useUIStore((s) => s.toggleBrowseExpandedDir);
+  const fileTreeVersion = useFileStore((s) => s.fileTreeVersion);
   const [cacheVersion, setCacheVersion] = useState(0);
 
-  // Re-fetch expanded directory contents when file tree refreshes
+  // Re-fetch expanded directory contents when file tree version changes
   useEffect(() => {
-    const handleRefresh = async () => {
+    if (fileTreeVersion === 0) return;
+    const refreshExpandedDirs = async () => {
       const expandedPaths = Array.from(expandedDirs);
       if (expandedPaths.length === 0) {
         dirContentsCache.clear();
@@ -75,10 +78,8 @@ function BrowseFileList({
       }
       setCacheVersion((v) => v + 1);
     };
-
-    window.addEventListener('file-tree-refresh', handleRefresh);
-    return () => window.removeEventListener('file-tree-refresh', handleRefresh);
-  }, [expandedDirs]);
+    refreshExpandedDirs();
+  }, [fileTreeVersion, expandedDirs]);
 
   const toggleDir = useCallback(
     async (path: string) => {

--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -14,7 +14,6 @@ import { GlobalSearch } from '@/components/GlobalSearch/GlobalSearch';
 import { ModalOverlay } from '@/components/ModalOverlay';
 import { indexProject, copyEntry, moveEntry, getClipboardFilePaths } from '@/lib/tauri';
 import { useContextMenuStore } from '@/stores/contextMenuStore';
-import { dispatchFileTreeRefresh } from '@/stores/contextMenuStore';
 import {
   PlusIcon,
   CloseIcon,
@@ -186,7 +185,7 @@ export function MainLayout() {
                   await copyEntry(clipboard.entry!.path, destPath);
                 }
                 clearClipboard();
-                dispatchFileTreeRefresh();
+                useFileStore.getState().invalidateFileTree();
               } catch (err) {
                 console.error('Failed to paste file:', err);
               }
@@ -224,7 +223,7 @@ export function MainLayout() {
                   }
                 }
               }
-              dispatchFileTreeRefresh();
+              useFileStore.getState().invalidateFileTree();
             } catch (err) {
               console.error('Failed to paste files from clipboard:', err);
             }

--- a/src/hooks/useFileBrowserState.ts
+++ b/src/hooks/useFileBrowserState.ts
@@ -10,7 +10,6 @@ import {
   FileEntry,
 } from '@/lib/tauri';
 import { openFileInBrowseMode } from '@/lib/fileUtils';
-import { dispatchFileTreeRefresh } from '@/stores/contextMenuStore';
 
 const AUTO_SAVE_DELAY = 1000;
 
@@ -26,7 +25,9 @@ export function useFileBrowserState() {
     updateBrowseFileContent,
     markBrowseFileSaved,
     refreshBrowseFileContent,
+    invalidateFileTree,
   } = useFileStore();
+  const fileTreeVersion = useFileStore((s) => s.fileTreeVersion);
 
   const [entries, setEntries] = useState<FileEntry[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -59,9 +60,9 @@ export function useFileBrowserState() {
 
   // Refresh file tree when file operations occur (rename, delete, paste)
   useEffect(() => {
-    window.addEventListener('file-tree-refresh', loadDirectory);
-    return () => window.removeEventListener('file-tree-refresh', loadDirectory);
-  }, [loadDirectory]);
+    if (fileTreeVersion === 0) return;
+    loadDirectory();
+  }, [fileTreeVersion, loadDirectory]);
 
   // File system watcher: auto-refresh on external changes
   const fsDebounceTimer = useRef<NodeJS.Timeout | null>(null);
@@ -86,7 +87,7 @@ export function useFileBrowserState() {
       }
       fsDebounceTimer.current = setTimeout(() => {
         fsDebounceTimer.current = null;
-        window.dispatchEvent(new Event('file-tree-refresh'));
+        useFileStore.getState().invalidateFileTree();
 
         // Re-read each open non-image file's content from disk
         const openFiles = useFileStore.getState().browseOpenFiles;
@@ -207,7 +208,7 @@ export function useFileBrowserState() {
     handleSelectFile,
     handleCloseFile,
     handleContentChange,
-    handleRefresh: dispatchFileTreeRefresh,
+    handleRefresh: invalidateFileTree,
     setBrowseActiveFile,
     getSaveStatus,
   };

--- a/src/stores/contextMenuStore.ts
+++ b/src/stores/contextMenuStore.ts
@@ -84,8 +84,3 @@ export const useContextMenuStore = create<ContextMenuState>((set) => ({
       deleteTarget: null,
     }),
 }));
-
-/** Dispatch this event after file operations to trigger tree refresh */
-export function dispatchFileTreeRefresh() {
-  window.dispatchEvent(new Event('file-tree-refresh'));
-}

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -95,6 +95,9 @@ interface FileState {
   clearPendingScrollToLine: () => void;
   openBrowseFileAtLine: (file: OpenFile, line: number) => void;
   reorderBrowseFiles: (fromIndex: number, toIndex: number) => void;
+  // File tree invalidation (replaces window event bus)
+  fileTreeVersion: number;
+  invalidateFileTree: () => void;
   // Find references panel
   referencesSymbol: string | null;
   showReferencesPanel: (symbol: string) => void;
@@ -189,6 +192,9 @@ export const useFileStore = create<FileState>()(
       reorderBrowseFiles: (fromIndex: number, toIndex: number) => {
         set({ browseOpenFiles: reorderArray(get().browseOpenFiles, fromIndex, toIndex) });
       },
+      // File tree invalidation (replaces window event bus)
+      fileTreeVersion: 0,
+      invalidateFileTree: () => set((s) => ({ fileTreeVersion: s.fileTreeVersion + 1 })),
       // Find references panel
       referencesSymbol: null,
       showReferencesPanel: (symbol: string) => set({ referencesSymbol: symbol }),


### PR DESCRIPTION
## Summary
- Replaces window `file-tree-refresh` custom events with an explicit `fileTreeVersion` counter in the Zustand file store
- All producers (context menu operations, keyboard paste, fs watcher) now call `invalidateFileTree()` instead of `window.dispatchEvent`
- All consumers (useFileBrowserState, BrowseFileListPanel) react to version changes via standard Zustand subscriptions
- Removes the `dispatchFileTreeRefresh` helper and all DOM event coupling

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)