### PR TITLE
feat: add baseline automated tests for critical flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Frontend tests
+        run: npm test
+
       - name: TypeScript check
         run: npm run build -- --mode development
 
@@ -47,6 +50,9 @@ jobs:
 
       - name: Rust clippy
         run: cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings
+
+      - name: Rust tests
+        run: cargo test --manifest-path src-tauri/Cargo.toml
 
   build-test:
     runs-on: ubuntu-22.04

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,8 @@
       "devDependencies": {
         "@eslint/js": "^9.0.0",
         "@tauri-apps/cli": "^2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/node": "^25.2.0",
         "@types/react": "^19.1.8",
         "@types/react-dom": "^19.1.6",
@@ -50,13 +52,29 @@
         "autoprefixer": "^10.4.21",
         "eslint": "^9.0.0",
         "eslint-plugin-react-hooks": "^5.1.0",
+        "jsdom": "^28.1.0",
         "postcss": "^8.5.3",
         "prettier": "^3.4.2",
         "tailwindcss": "^3.4.17",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.0.0",
-        "vite": "^7.0.4"
+        "vite": "^7.0.4",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -70,6 +88,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -306,6 +379,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -352,6 +435,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -545,6 +641,140 @@
         "crelt": "^1.0.6",
         "style-mod": "^4.1.0",
         "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
+      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
+      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.1",
+        "@csstools/css-calc": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.27",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
+      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1131,6 +1361,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1747,6 +1995,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.10.1",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.10.1.tgz",
@@ -2010,6 +2265,89 @@
         "@tauri-apps/api": "^2.10.1"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2055,6 +2393,24 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2097,6 +2453,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2392,6 +2749,117 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xterm/addon-fit": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.10.0.tgz",
@@ -2447,6 +2915,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2462,6 +2940,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2515,6 +3003,26 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.24",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.24.tgz",
@@ -2567,6 +3075,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2681,6 +3199,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2802,6 +3330,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2815,12 +3364,52 @@
         "node": ">=4"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.0.1.tgz",
+      "integrity": "sha512-IoJs7La+oFp/AB033wBStxNOJt4+9hHMxsXUPANcoXL2b3W4DZKghlJ2cI/eyeRZIQ9ysvYEorVhjrcYctWbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.26",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2840,12 +3429,29 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -2870,12 +3476,39 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.286",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
       "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.2",
@@ -3100,6 +3733,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3108,6 +3751,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3342,6 +3995,47 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3377,6 +4071,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-binary-path": {
@@ -3441,6 +4145,13 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3477,6 +4188,48 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3603,6 +4356,33 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -3625,6 +4405,16 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3722,6 +4512,17 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -3785,6 +4586,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3809,6 +4623,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -3999,6 +4820,34 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -4053,6 +4902,13 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4104,6 +4960,30 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4217,6 +5097,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -4256,6 +5149,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4264,6 +5164,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4333,6 +5260,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",
@@ -4438,6 +5372,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4487,6 +5438,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4498,6 +5479,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4570,6 +5577,16 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -4735,11 +5752,150 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.0.tgz",
+      "integrity": "sha512-9CcxtEKsf53UFwkSUZjG+9vydAsFO4lFHBpJUtjBcoJOCJpKnSJNwCw813zrYJHpCJ7sgfbtOe0V5Ku7Pa1XMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -4757,6 +5913,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4766,6 +5939,23 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "tauri": "tauri",
     "lint": "eslint src --ext .ts,.tsx",
     "format": "prettier --write \"src/**/*.{ts,tsx,css}\" && cargo fmt --manifest-path src-tauri/Cargo.toml && cargo clippy --manifest-path src-tauri/Cargo.toml -- -D warnings",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "release:major": "./scripts/release.sh major",
     "release:minor": "./scripts/release.sh minor",
     "release:patch": "./scripts/release.sh patch"
@@ -52,6 +54,8 @@
   "devDependencies": {
     "@eslint/js": "^9.0.0",
     "@tauri-apps/cli": "^2",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/node": "^25.2.0",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
@@ -59,11 +63,13 @@
     "autoprefixer": "^10.4.21",
     "eslint": "^9.0.0",
     "eslint-plugin-react-hooks": "^5.1.0",
+    "jsdom": "^28.1.0",
     "postcss": "^8.5.3",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.17",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.0.0",
-    "vite": "^7.0.4"
+    "vite": "^7.0.4",
+    "vitest": "^4.0.18"
   }
 }

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -490,3 +490,75 @@ return paths as text
         Vec::new()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod validate_path_tests {
+        use super::*;
+
+        #[test]
+        fn accepts_absolute_path() {
+            let result = validate_path("/home/user/project");
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap(), PathBuf::from("/home/user/project"));
+        }
+
+        #[test]
+        fn rejects_relative_path() {
+            let result = validate_path("relative/path");
+            assert!(result.is_err());
+            match result.unwrap_err() {
+                FileSystemError::InvalidPath(msg) => {
+                    assert!(msg.contains("must be absolute"));
+                }
+                other => panic!("Expected InvalidPath, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn rejects_path_with_parent_traversal() {
+            let result = validate_path("/home/user/../etc/passwd");
+            assert!(result.is_err());
+            match result.unwrap_err() {
+                FileSystemError::InvalidPath(msg) => {
+                    assert!(msg.contains("must not contain '..'"));
+                }
+                other => panic!("Expected InvalidPath, got {:?}", other),
+            }
+        }
+
+        #[test]
+        fn accepts_path_with_dots_in_names() {
+            // ".hidden" is a normal component, not a parent dir reference
+            let result = validate_path("/home/user/.hidden/file.txt");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn rejects_bare_relative_path() {
+            let result = validate_path("file.txt");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn accepts_root_path() {
+            let result = validate_path("/");
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn rejects_dot_dot_at_start() {
+            let result = validate_path("/../etc");
+            assert!(result.is_err());
+        }
+
+        #[test]
+        fn accepts_path_with_current_dir_component() {
+            // "." (current dir) is allowed, only ".." is blocked
+            let result = validate_path("/home/./user");
+            assert!(result.is_ok());
+        }
+    }
+}

--- a/src-tauri/src/git.rs
+++ b/src-tauri/src/git.rs
@@ -801,3 +801,153 @@ pub fn list_branches(repo_path: String) -> Result<Vec<GitBranch>, GitError> {
 
     Ok(branches)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod validate_no_flag {
+        use super::*;
+
+        #[test]
+        fn rejects_flag_starting_with_dash() {
+            let result = validate_no_flag("--exec", "branch name");
+            assert!(result.is_err());
+            let err = result.unwrap_err();
+            assert!(
+                matches!(err, GitError::InvalidArgument(_)),
+                "Expected InvalidArgument, got {:?}",
+                err
+            );
+        }
+
+        #[test]
+        fn rejects_single_dash_flag() {
+            assert!(validate_no_flag("-v", "arg").is_err());
+        }
+
+        #[test]
+        fn accepts_normal_branch_name() {
+            assert!(validate_no_flag("main", "branch name").is_ok());
+            assert!(validate_no_flag("feature/my-branch", "branch name").is_ok());
+        }
+
+        #[test]
+        fn accepts_empty_string() {
+            assert!(validate_no_flag("", "arg").is_ok());
+        }
+
+        #[test]
+        fn accepts_path_like_strings() {
+            assert!(validate_no_flag("src/lib/main.rs", "file path").is_ok());
+            assert!(validate_no_flag("file.txt", "file path").is_ok());
+        }
+    }
+
+    mod is_image_extension_tests {
+        use super::*;
+
+        #[test]
+        fn detects_common_image_formats() {
+            assert!(is_image_extension("photo.png"));
+            assert!(is_image_extension("photo.jpg"));
+            assert!(is_image_extension("photo.jpeg"));
+            assert!(is_image_extension("photo.gif"));
+            assert!(is_image_extension("icon.svg"));
+            assert!(is_image_extension("photo.webp"));
+            assert!(is_image_extension("photo.bmp"));
+            assert!(is_image_extension("favicon.ico"));
+        }
+
+        #[test]
+        fn case_insensitive() {
+            assert!(is_image_extension("PHOTO.PNG"));
+            assert!(is_image_extension("Photo.JPG"));
+            assert!(is_image_extension("icon.SVG"));
+        }
+
+        #[test]
+        fn rejects_non_image_extensions() {
+            assert!(!is_image_extension("main.rs"));
+            assert!(!is_image_extension("style.css"));
+            assert!(!is_image_extension("data.json"));
+            assert!(!is_image_extension("README.md"));
+        }
+
+        #[test]
+        fn handles_paths_with_directories() {
+            assert!(is_image_extension("src/assets/logo.png"));
+            assert!(is_image_extension("/home/user/photo.jpg"));
+            assert!(!is_image_extension("src/lib/main.ts"));
+        }
+
+        #[test]
+        fn handles_no_extension() {
+            assert!(!is_image_extension("Makefile"));
+            assert!(!is_image_extension(""));
+        }
+
+        #[test]
+        fn handles_multiple_dots() {
+            assert!(is_image_extension("my.photo.backup.png"));
+            assert!(!is_image_extension("archive.tar.gz"));
+        }
+    }
+
+    mod index_status_to_string_tests {
+        use super::*;
+
+        #[test]
+        fn maps_index_new() {
+            assert_eq!(index_status_to_string(git2::Status::INDEX_NEW), "added");
+        }
+
+        #[test]
+        fn maps_index_modified() {
+            assert_eq!(
+                index_status_to_string(git2::Status::INDEX_MODIFIED),
+                "modified"
+            );
+        }
+
+        #[test]
+        fn maps_index_deleted() {
+            assert_eq!(
+                index_status_to_string(git2::Status::INDEX_DELETED),
+                "deleted"
+            );
+        }
+
+        #[test]
+        fn maps_index_renamed() {
+            assert_eq!(
+                index_status_to_string(git2::Status::INDEX_RENAMED),
+                "renamed"
+            );
+        }
+    }
+
+    mod wt_status_to_string_tests {
+        use super::*;
+
+        #[test]
+        fn maps_wt_new() {
+            assert_eq!(wt_status_to_string(git2::Status::WT_NEW), "added");
+        }
+
+        #[test]
+        fn maps_wt_modified() {
+            assert_eq!(wt_status_to_string(git2::Status::WT_MODIFIED), "modified");
+        }
+
+        #[test]
+        fn maps_wt_deleted() {
+            assert_eq!(wt_status_to_string(git2::Status::WT_DELETED), "deleted");
+        }
+
+        #[test]
+        fn maps_wt_renamed() {
+            assert_eq!(wt_status_to_string(git2::Status::WT_RENAMED), "renamed");
+        }
+    }
+}

--- a/src/__tests__/conflictParser.test.ts
+++ b/src/__tests__/conflictParser.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { parseConflicts, resolveConflict, hasConflictMarkers } from '@/lib/conflictParser';
+
+describe('parseConflicts', () => {
+  it('returns null for content without conflicts', () => {
+    expect(parseConflicts('hello\nworld')).toBeNull();
+    expect(parseConflicts('')).toBeNull();
+  });
+
+  it('parses a single conflict', () => {
+    const content = [
+      'before',
+      '<<<<<<< HEAD',
+      'our line',
+      '=======',
+      'their line',
+      '>>>>>>> feature',
+      'after',
+    ].join('\n');
+
+    const segments = parseConflicts(content);
+    expect(segments).not.toBeNull();
+    expect(segments).toHaveLength(3);
+
+    expect(segments![0]).toEqual({ kind: 'normal', lines: ['before'] });
+    expect(segments![1]).toEqual({
+      kind: 'conflict',
+      oursLabel: 'HEAD',
+      theirsLabel: 'feature',
+      oursLines: ['our line'],
+      theirsLines: ['their line'],
+    });
+    expect(segments![2]).toEqual({ kind: 'normal', lines: ['after'] });
+  });
+
+  it('parses multiple conflicts', () => {
+    const content = [
+      '<<<<<<< HEAD',
+      'a',
+      '=======',
+      'b',
+      '>>>>>>> branch1',
+      'middle',
+      '<<<<<<< HEAD',
+      'c',
+      '=======',
+      'd',
+      '>>>>>>> branch2',
+    ].join('\n');
+
+    const segments = parseConflicts(content);
+    expect(segments).not.toBeNull();
+    expect(segments).toHaveLength(3);
+    expect(segments![0].kind).toBe('conflict');
+    expect(segments![1]).toEqual({ kind: 'normal', lines: ['middle'] });
+    expect(segments![2].kind).toBe('conflict');
+  });
+
+  it('handles multi-line conflict sections', () => {
+    const content = [
+      '<<<<<<< HEAD',
+      'line 1',
+      'line 2',
+      '=======',
+      'line 3',
+      'line 4',
+      'line 5',
+      '>>>>>>> feature',
+    ].join('\n');
+
+    const segments = parseConflicts(content);
+    expect(segments).not.toBeNull();
+    expect(segments).toHaveLength(1);
+    const conflict = segments![0];
+    expect(conflict.kind).toBe('conflict');
+    if (conflict.kind === 'conflict') {
+      expect(conflict.oursLines).toEqual(['line 1', 'line 2']);
+      expect(conflict.theirsLines).toEqual(['line 3', 'line 4', 'line 5']);
+    }
+  });
+
+  it('uses default labels when none provided', () => {
+    const content = ['<<<<<<<', 'ours', '=======', 'theirs', '>>>>>>>'].join('\n');
+
+    const segments = parseConflicts(content);
+    expect(segments).not.toBeNull();
+    const conflict = segments![0];
+    if (conflict.kind === 'conflict') {
+      expect(conflict.oursLabel).toBe('Current Change');
+      expect(conflict.theirsLabel).toBe('Incoming Change');
+    }
+  });
+
+  it('handles empty conflict sections', () => {
+    const content = ['<<<<<<< HEAD', '=======', '>>>>>>> feature'].join('\n');
+
+    const segments = parseConflicts(content);
+    expect(segments).not.toBeNull();
+    const conflict = segments![0];
+    if (conflict.kind === 'conflict') {
+      expect(conflict.oursLines).toEqual([]);
+      expect(conflict.theirsLines).toEqual([]);
+    }
+  });
+});
+
+describe('resolveConflict', () => {
+  const segments = parseConflicts(
+    [
+      'before',
+      '<<<<<<< HEAD',
+      'our change',
+      '=======',
+      'their change',
+      '>>>>>>> feature',
+      'after',
+    ].join('\n')
+  )!;
+
+  it('resolves with ours', () => {
+    const result = resolveConflict(segments, 0, 'ours');
+    expect(result).toBe('before\nour change\nafter');
+  });
+
+  it('resolves with theirs', () => {
+    const result = resolveConflict(segments, 0, 'theirs');
+    expect(result).toBe('before\ntheir change\nafter');
+  });
+
+  it('resolves with both', () => {
+    const result = resolveConflict(segments, 0, 'both');
+    expect(result).toBe('before\nour change\ntheir change\nafter');
+  });
+
+  it('preserves other conflicts when resolving one', () => {
+    const multiConflict = parseConflicts(
+      [
+        '<<<<<<< HEAD',
+        'a',
+        '=======',
+        'b',
+        '>>>>>>> branch',
+        '<<<<<<< HEAD',
+        'c',
+        '=======',
+        'd',
+        '>>>>>>> branch',
+      ].join('\n')
+    )!;
+
+    const result = resolveConflict(multiConflict, 0, 'ours');
+    // First conflict resolved to 'a', second preserved with markers
+    expect(result).toContain('a\n<<<<<<< HEAD');
+    expect(result).toContain('>>>>>>> branch');
+  });
+});
+
+describe('hasConflictMarkers', () => {
+  it('returns true when markers are present', () => {
+    expect(hasConflictMarkers('<<<<<<< HEAD\ncode\n=======\nother\n>>>>>>> branch')).toBe(true);
+  });
+
+  it('returns false when no markers', () => {
+    expect(hasConflictMarkers('normal code\nno conflicts here')).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(hasConflictMarkers('')).toBe(false);
+  });
+
+  it('requires at least 7 angle brackets', () => {
+    expect(hasConflictMarkers('<<<<<< not enough')).toBe(false);
+    expect(hasConflictMarkers('<<<<<<< enough')).toBe(true);
+  });
+});

--- a/src/__tests__/fileStore.test.ts
+++ b/src/__tests__/fileStore.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useFileStore } from '@/stores/fileStore';
+import type { OpenFile } from '@/stores/fileStore';
+
+// Helper to create test files
+function makeFile(path: string, name?: string): OpenFile {
+  return {
+    path,
+    name: name ?? path.split('/').pop() ?? path,
+    content: `content of ${path}`,
+    isDirty: false,
+    language: 'typescript',
+  };
+}
+
+describe('fileStore', () => {
+  beforeEach(() => {
+    // Reset the store between tests
+    useFileStore.setState({
+      currentDirectory: null,
+      activeWorktreePath: null,
+      contextPath: null,
+      savedBrowseState: {},
+      browseOpenFiles: [],
+      browseActiveFilePath: null,
+      pendingScrollToLine: null,
+      pendingScrollToFile: null,
+      referencesSymbol: null,
+    });
+  });
+
+  describe('openBrowseFile', () => {
+    it('adds a new file and sets it active', () => {
+      const file = makeFile('/project/src/main.ts');
+      useFileStore.getState().openBrowseFile(file);
+
+      const state = useFileStore.getState();
+      expect(state.browseOpenFiles).toHaveLength(1);
+      expect(state.browseOpenFiles[0].path).toBe('/project/src/main.ts');
+      expect(state.browseActiveFilePath).toBe('/project/src/main.ts');
+    });
+
+    it('does not duplicate an already-open file', () => {
+      const file = makeFile('/project/src/main.ts');
+      useFileStore.getState().openBrowseFile(file);
+      useFileStore.getState().openBrowseFile(file);
+
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(1);
+    });
+
+    it('activates an already-open file without duplicating', () => {
+      const file1 = makeFile('/project/a.ts');
+      const file2 = makeFile('/project/b.ts');
+
+      useFileStore.getState().openBrowseFile(file1);
+      useFileStore.getState().openBrowseFile(file2);
+      expect(useFileStore.getState().browseActiveFilePath).toBe('/project/b.ts');
+
+      useFileStore.getState().openBrowseFile(file1);
+      expect(useFileStore.getState().browseActiveFilePath).toBe('/project/a.ts');
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(2);
+    });
+  });
+
+  describe('closeBrowseFile', () => {
+    it('removes the file from open files', () => {
+      const file = makeFile('/project/a.ts');
+      useFileStore.getState().openBrowseFile(file);
+      useFileStore.getState().closeBrowseFile('/project/a.ts');
+
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(0);
+    });
+
+    it('sets active to last remaining file when closing the active file', () => {
+      const file1 = makeFile('/project/a.ts');
+      const file2 = makeFile('/project/b.ts');
+      const file3 = makeFile('/project/c.ts');
+
+      useFileStore.getState().openBrowseFile(file1);
+      useFileStore.getState().openBrowseFile(file2);
+      useFileStore.getState().openBrowseFile(file3);
+
+      // Active is c.ts, close it
+      useFileStore.getState().closeBrowseFile('/project/c.ts');
+      expect(useFileStore.getState().browseActiveFilePath).toBe('/project/b.ts');
+    });
+
+    it('sets active to null when closing the last file', () => {
+      const file = makeFile('/project/a.ts');
+      useFileStore.getState().openBrowseFile(file);
+      useFileStore.getState().closeBrowseFile('/project/a.ts');
+
+      expect(useFileStore.getState().browseActiveFilePath).toBeNull();
+    });
+
+    it('preserves active file when closing a non-active file', () => {
+      const file1 = makeFile('/project/a.ts');
+      const file2 = makeFile('/project/b.ts');
+
+      useFileStore.getState().openBrowseFile(file1);
+      useFileStore.getState().openBrowseFile(file2);
+      // Active is b.ts
+      useFileStore.getState().closeBrowseFile('/project/a.ts');
+
+      expect(useFileStore.getState().browseActiveFilePath).toBe('/project/b.ts');
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(1);
+    });
+  });
+
+  describe('updateBrowseFileContent', () => {
+    it('updates content and marks file dirty', () => {
+      const file = makeFile('/project/a.ts');
+      useFileStore.getState().openBrowseFile(file);
+      useFileStore.getState().updateBrowseFileContent('/project/a.ts', 'new content');
+
+      const updated = useFileStore.getState().browseOpenFiles[0];
+      expect(updated.content).toBe('new content');
+      expect(updated.isDirty).toBe(true);
+    });
+  });
+
+  describe('markBrowseFileSaved', () => {
+    it('clears dirty flag', () => {
+      const file = makeFile('/project/a.ts');
+      useFileStore.getState().openBrowseFile(file);
+      useFileStore.getState().updateBrowseFileContent('/project/a.ts', 'modified');
+      expect(useFileStore.getState().browseOpenFiles[0].isDirty).toBe(true);
+
+      useFileStore.getState().markBrowseFileSaved('/project/a.ts');
+      expect(useFileStore.getState().browseOpenFiles[0].isDirty).toBe(false);
+    });
+  });
+
+  describe('syncTabContext', () => {
+    it('saves and restores browse state when switching contexts', () => {
+      // Set up context A with an open file
+      useFileStore.setState({ contextPath: '/project-a' });
+      const fileA = makeFile('/project-a/src/main.ts');
+      useFileStore.getState().openBrowseFile(fileA);
+
+      // Switch to context B
+      useFileStore.getState().syncTabContext('/project-b', null);
+      expect(useFileStore.getState().contextPath).toBe('/project-b');
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(0);
+
+      // Open a file in context B
+      const fileB = makeFile('/project-b/src/app.ts');
+      useFileStore.getState().openBrowseFile(fileB);
+
+      // Switch back to context A - should restore context A's files
+      useFileStore.getState().syncTabContext('/project-a', null);
+      expect(useFileStore.getState().contextPath).toBe('/project-a');
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(1);
+      expect(useFileStore.getState().browseOpenFiles[0].path).toBe('/project-a/src/main.ts');
+    });
+
+    it('does nothing when context has not changed', () => {
+      useFileStore.setState({ contextPath: '/project' });
+      const file = makeFile('/project/main.ts');
+      useFileStore.getState().openBrowseFile(file);
+
+      useFileStore.getState().syncTabContext('/project', null);
+      // Files should remain unchanged
+      expect(useFileStore.getState().browseOpenFiles).toHaveLength(1);
+    });
+
+    it('uses worktree path as context when provided', () => {
+      useFileStore.setState({ contextPath: '/main-project' });
+      useFileStore.getState().syncTabContext('/main-project', '/worktree-path');
+      expect(useFileStore.getState().contextPath).toBe('/worktree-path');
+    });
+  });
+
+  describe('reorderBrowseFiles', () => {
+    it('reorders open files', () => {
+      useFileStore.getState().openBrowseFile(makeFile('/a.ts'));
+      useFileStore.getState().openBrowseFile(makeFile('/b.ts'));
+      useFileStore.getState().openBrowseFile(makeFile('/c.ts'));
+
+      useFileStore.getState().reorderBrowseFiles(0, 2);
+
+      const paths = useFileStore.getState().browseOpenFiles.map((f) => f.path);
+      expect(paths).toEqual(['/b.ts', '/c.ts', '/a.ts']);
+    });
+  });
+
+  describe('openBrowseFileAtLine', () => {
+    it('sets pending scroll line and file', () => {
+      const file = makeFile('/project/main.ts');
+      useFileStore.getState().openBrowseFileAtLine(file, 42);
+
+      const state = useFileStore.getState();
+      expect(state.pendingScrollToLine).toBe(42);
+      expect(state.pendingScrollToFile).toBe('/project/main.ts');
+      expect(state.browseActiveFilePath).toBe('/project/main.ts');
+    });
+  });
+
+  describe('setCurrentDirectory', () => {
+    it('clears browse files when setting new directory', () => {
+      useFileStore.getState().openBrowseFile(makeFile('/old/file.ts'));
+      useFileStore.getState().setCurrentDirectory('/new/project');
+
+      const state = useFileStore.getState();
+      expect(state.currentDirectory).toBe('/new/project');
+      expect(state.contextPath).toBe('/new/project');
+      expect(state.browseOpenFiles).toHaveLength(0);
+      expect(state.browseActiveFilePath).toBeNull();
+    });
+  });
+});

--- a/src/__tests__/fileUtils.test.ts
+++ b/src/__tests__/fileUtils.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isImageFile,
+  getImageMimeType,
+  buildImageDataUrl,
+  getFileIconColor,
+  getFileName,
+  toggleSetItem,
+  reorderArray,
+  sortDirectoriesFirst,
+} from '@/lib/fileUtils';
+
+describe('isImageFile', () => {
+  it('returns true for image extensions', () => {
+    expect(isImageFile('photo.png')).toBe(true);
+    expect(isImageFile('photo.jpg')).toBe(true);
+    expect(isImageFile('photo.jpeg')).toBe(true);
+    expect(isImageFile('photo.gif')).toBe(true);
+    expect(isImageFile('icon.svg')).toBe(true);
+    expect(isImageFile('photo.webp')).toBe(true);
+    expect(isImageFile('photo.bmp')).toBe(true);
+    expect(isImageFile('favicon.ico')).toBe(true);
+  });
+
+  it('returns false for non-image extensions', () => {
+    expect(isImageFile('main.ts')).toBe(false);
+    expect(isImageFile('styles.css')).toBe(false);
+    expect(isImageFile('README.md')).toBe(false);
+    expect(isImageFile('data.json')).toBe(false);
+  });
+
+  it('is case insensitive', () => {
+    expect(isImageFile('PHOTO.PNG')).toBe(true);
+    expect(isImageFile('photo.JPG')).toBe(true);
+  });
+
+  it('handles paths with directories', () => {
+    expect(isImageFile('src/assets/logo.png')).toBe(true);
+    expect(isImageFile('/home/user/file.ts')).toBe(false);
+  });
+
+  it('handles edge cases', () => {
+    expect(isImageFile('')).toBe(false);
+    expect(isImageFile('noextension')).toBe(false);
+  });
+});
+
+describe('getImageMimeType', () => {
+  it('returns correct mime types', () => {
+    expect(getImageMimeType('photo.png')).toBe('image/png');
+    expect(getImageMimeType('photo.jpg')).toBe('image/jpeg');
+    expect(getImageMimeType('photo.jpeg')).toBe('image/jpeg');
+    expect(getImageMimeType('photo.gif')).toBe('image/gif');
+    expect(getImageMimeType('icon.svg')).toBe('image/svg+xml');
+    expect(getImageMimeType('photo.webp')).toBe('image/webp');
+    expect(getImageMimeType('photo.bmp')).toBe('image/bmp');
+    expect(getImageMimeType('favicon.ico')).toBe('image/x-icon');
+  });
+
+  it('returns octet-stream for unknown extensions', () => {
+    expect(getImageMimeType('file.xyz')).toBe('application/octet-stream');
+    expect(getImageMimeType('file.ts')).toBe('application/octet-stream');
+  });
+});
+
+describe('buildImageDataUrl', () => {
+  it('builds correct data URL', () => {
+    expect(buildImageDataUrl('abc123', 'photo.png')).toBe('data:image/png;base64,abc123');
+    expect(buildImageDataUrl('xyz', 'icon.svg')).toBe('data:image/svg+xml;base64,xyz');
+  });
+});
+
+describe('getFileIconColor', () => {
+  it('returns correct colors for known extensions', () => {
+    expect(getFileIconColor('main.ts')).toBe('text-blue-400');
+    expect(getFileIconColor('App.tsx')).toBe('text-blue-400');
+    expect(getFileIconColor('index.js')).toBe('text-yellow-400');
+    expect(getFileIconColor('Component.jsx')).toBe('text-yellow-400');
+    expect(getFileIconColor('lib.rs')).toBe('text-orange-400');
+    expect(getFileIconColor('script.py')).toBe('text-green-400');
+    expect(getFileIconColor('config.json')).toBe('text-yellow-300');
+    expect(getFileIconColor('README.md')).toBe('text-blue-300');
+    expect(getFileIconColor('styles.css')).toBe('text-pink-400');
+    expect(getFileIconColor('styles.scss')).toBe('text-pink-400');
+    expect(getFileIconColor('index.html')).toBe('text-orange-300');
+  });
+
+  it('returns default color for unknown extensions', () => {
+    expect(getFileIconColor('Makefile')).toBe('text-tertiary');
+    expect(getFileIconColor('unknown.xyz')).toBe('text-tertiary');
+  });
+
+  it('accepts a custom default color', () => {
+    expect(getFileIconColor('unknown.xyz', 'text-gray-500')).toBe('text-gray-500');
+  });
+});
+
+describe('getFileName', () => {
+  it('extracts filename from path', () => {
+    expect(getFileName('src/lib/fileUtils.ts')).toBe('fileUtils.ts');
+    expect(getFileName('/home/user/project/main.rs')).toBe('main.rs');
+  });
+
+  it('returns the input for bare filenames', () => {
+    expect(getFileName('file.txt')).toBe('file.txt');
+  });
+
+  it('handles trailing slash edge case', () => {
+    // split('/').pop() returns '' for trailing slash
+    expect(getFileName('src/')).toBe('src/');
+  });
+
+  it('handles empty string', () => {
+    expect(getFileName('')).toBe('');
+  });
+});
+
+describe('toggleSetItem', () => {
+  it('adds item not in set', () => {
+    const set = new Set([1, 2, 3]);
+    const result = toggleSetItem(set, 4);
+    expect(result.has(4)).toBe(true);
+    expect(result.size).toBe(4);
+  });
+
+  it('removes item already in set', () => {
+    const set = new Set([1, 2, 3]);
+    const result = toggleSetItem(set, 2);
+    expect(result.has(2)).toBe(false);
+    expect(result.size).toBe(2);
+  });
+
+  it('does not mutate original set', () => {
+    const set = new Set([1, 2, 3]);
+    toggleSetItem(set, 4);
+    expect(set.size).toBe(3);
+    expect(set.has(4)).toBe(false);
+  });
+
+  it('works with strings', () => {
+    const set = new Set(['a', 'b']);
+    expect(toggleSetItem(set, 'c').has('c')).toBe(true);
+    expect(toggleSetItem(set, 'a').has('a')).toBe(false);
+  });
+});
+
+describe('reorderArray', () => {
+  it('moves item forward', () => {
+    expect(reorderArray([1, 2, 3, 4], 0, 2)).toEqual([2, 3, 1, 4]);
+  });
+
+  it('moves item backward', () => {
+    expect(reorderArray([1, 2, 3, 4], 3, 1)).toEqual([1, 4, 2, 3]);
+  });
+
+  it('returns same order if indices are equal', () => {
+    expect(reorderArray([1, 2, 3], 1, 1)).toEqual([1, 2, 3]);
+  });
+
+  it('does not mutate the original array', () => {
+    const arr = [1, 2, 3];
+    reorderArray(arr, 0, 2);
+    expect(arr).toEqual([1, 2, 3]);
+  });
+});
+
+describe('sortDirectoriesFirst', () => {
+  it('sorts directories before files', () => {
+    const entries = [
+      { name: 'file.ts', isDirectory: false },
+      { name: 'src', isDirectory: true },
+      { name: 'another.ts', isDirectory: false },
+      { name: 'lib', isDirectory: true },
+    ];
+    const sorted = sortDirectoriesFirst(entries);
+    expect(sorted.map((e) => e.name)).toEqual(['lib', 'src', 'another.ts', 'file.ts']);
+  });
+
+  it('sorts alphabetically within same type', () => {
+    const entries = [
+      { name: 'z.ts', isDirectory: false },
+      { name: 'a.ts', isDirectory: false },
+      { name: 'm.ts', isDirectory: false },
+    ];
+    const sorted = sortDirectoriesFirst(entries);
+    expect(sorted.map((e) => e.name)).toEqual(['a.ts', 'm.ts', 'z.ts']);
+  });
+
+  it('does not mutate the original array', () => {
+    const entries = [
+      { name: 'b.ts', isDirectory: false },
+      { name: 'a', isDirectory: true },
+    ];
+    const original = [...entries];
+    sortDirectoriesFirst(entries);
+    expect(entries).toEqual(original);
+  });
+
+  it('handles empty array', () => {
+    expect(sortDirectoriesFirst([])).toEqual([]);
+  });
+});

--- a/src/__tests__/highlight.test.ts
+++ b/src/__tests__/highlight.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { getLanguageFromPath } from '@/lib/highlight';
+
+describe('getLanguageFromPath', () => {
+  it('maps JavaScript extensions', () => {
+    expect(getLanguageFromPath('file.js')).toBe('javascript');
+    expect(getLanguageFromPath('file.jsx')).toBe('javascript');
+    expect(getLanguageFromPath('file.mjs')).toBe('javascript');
+    expect(getLanguageFromPath('file.cjs')).toBe('javascript');
+  });
+
+  it('maps TypeScript extensions', () => {
+    expect(getLanguageFromPath('file.ts')).toBe('typescript');
+    expect(getLanguageFromPath('file.tsx')).toBe('typescript');
+  });
+
+  it('maps systems language extensions', () => {
+    expect(getLanguageFromPath('lib.rs')).toBe('rust');
+    expect(getLanguageFromPath('main.go')).toBe('go');
+    expect(getLanguageFromPath('main.c')).toBe('c');
+    expect(getLanguageFromPath('main.h')).toBe('c');
+    expect(getLanguageFromPath('main.cpp')).toBe('cpp');
+  });
+
+  it('maps scripting language extensions', () => {
+    expect(getLanguageFromPath('script.py')).toBe('python');
+    expect(getLanguageFromPath('script.sh')).toBe('bash');
+    expect(getLanguageFromPath('script.bash')).toBe('bash');
+    expect(getLanguageFromPath('script.zsh')).toBe('bash');
+  });
+
+  it('maps data format extensions', () => {
+    expect(getLanguageFromPath('config.json')).toBe('json');
+    expect(getLanguageFromPath('config.yaml')).toBe('yaml');
+    expect(getLanguageFromPath('config.yml')).toBe('yaml');
+    expect(getLanguageFromPath('data.xml')).toBe('xml');
+  });
+
+  it('maps web extensions', () => {
+    expect(getLanguageFromPath('index.html')).toBe('html');
+    expect(getLanguageFromPath('styles.css')).toBe('css');
+    expect(getLanguageFromPath('styles.scss')).toBe('css');
+  });
+
+  it('maps JVM language extensions', () => {
+    expect(getLanguageFromPath('Main.java')).toBe('java');
+    expect(getLanguageFromPath('Main.scala')).toBe('scala');
+  });
+
+  it('maps documentation extensions', () => {
+    expect(getLanguageFromPath('README.md')).toBe('markdown');
+    expect(getLanguageFromPath('docs.markdown')).toBe('markdown');
+  });
+
+  it('returns undefined for unknown extensions', () => {
+    expect(getLanguageFromPath('file.xyz')).toBeUndefined();
+    expect(getLanguageFromPath('Makefile')).toBeUndefined();
+  });
+
+  it('handles paths with directories', () => {
+    expect(getLanguageFromPath('src/lib/utils.ts')).toBe('typescript');
+    expect(getLanguageFromPath('/home/user/project/main.rs')).toBe('rust');
+  });
+
+  it('returns undefined for files with no extension', () => {
+    expect(getLanguageFromPath('Dockerfile')).toBeUndefined();
+  });
+});

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/__tests__/setup.ts'],
+    include: ['src/**/*.test.{ts,tsx}'],
+  },
+});


### PR DESCRIPTION
## Summary
- Adds vitest setup with @testing-library/react for frontend tests
- Adds focused tests for fileUtils, conflictParser, highlight, and fileStore (67 frontend tests)
- Adds Rust unit tests for binary diff handling (is_image_extension), path validation (validate_path, validate_no_flag), and git status mappers (27 Rust tests)
- Integrates test execution into CI pipeline (vitest in lint-and-typecheck, cargo test in rust-check)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)