### PR TITLE
fix: recognize git init in existing terminal tabs

### DIFF
--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -202,15 +202,26 @@ export function MainLayout() {
     });
   }, [contextPath]);
 
-  // Derive active tab's cwd outside the effect so it only re-runs when the cwd changes
-  const activeTabCwd = tabs.find((t) => t.id === activeTabId)?.cwd;
+  // Derive active tab's cwd and gitRoot outside the effect so it only re-runs when they change
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+  const activeTabCwd = activeTab?.cwd;
+  const activeTabGitRoot = activeTab?.gitRoot;
 
-  // Sync file tree context with active terminal's cwd via git root detection
+  // Sync file tree context with active terminal's cwd / git root.
+  // Re-fires when gitRoot changes (e.g. after `git init` is detected by polling).
   useEffect(() => {
-    if (import.meta.env.DEV) console.log('[CWD] MainLayout effect fired:', { activeTabCwd });
+    if (import.meta.env.DEV) console.log('[CWD] MainLayout effect fired:', { activeTabCwd, activeTabGitRoot });
     if (!activeTabCwd) return;
-    let cancelled = false;
 
+    // If useTabGitRoots has already resolved the git root, use it directly
+    // instead of making a redundant async getGitRoot call.
+    if (activeTabGitRoot !== undefined) {
+      syncTabContext(activeTabGitRoot);
+      return;
+    }
+
+    // Fallback for the brief window before useTabGitRoots resolves
+    let cancelled = false;
     getGitRoot(activeTabCwd).then((gitRoot) => {
       if (import.meta.env.DEV) console.log('[CWD] getGitRoot resolved:', { activeTabCwd, gitRoot });
       if (!cancelled) {
@@ -221,7 +232,7 @@ export function MainLayout() {
     return () => {
       cancelled = true;
     };
-  }, [activeTabCwd, syncTabContext]);
+  }, [activeTabCwd, activeTabGitRoot, syncTabContext]);
 
   // Index project for symbol navigation when context path changes (deferred to avoid blocking startup)
   useEffect(() => {

--- a/src/hooks/useTabGitRoots.ts
+++ b/src/hooks/useTabGitRoots.ts
@@ -1,14 +1,20 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useTerminalStore } from '@/stores/terminalStore';
 import { getGitRepoInfo } from '@/lib/tauri';
 
 /**
  * Resolves git repo info for all terminal tabs that haven't been resolved yet.
  * Watches the tabs array and triggers resolution when gitRoot is undefined.
+ * Also periodically re-checks tabs where gitRoot is null (no repo detected)
+ * so that running `git init` in an existing tab is picked up automatically.
  */
 export function useTabGitRoots() {
   const tabs = useTerminalStore((s) => s.tabs);
   const setTabRepoInfo = useTerminalStore((s) => s.setTabRepoInfo);
+
+  // Keep a ref so the polling interval can read current tabs without re-mounting
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
 
   useEffect(() => {
     let cancelled = false;
@@ -31,4 +37,27 @@ export function useTabGitRoots() {
       cancelled = true;
     };
   }, [tabs, setTabRepoInfo]);
+
+  // Periodically re-check tabs where gitRoot is null (not a repo yet).
+  // This detects `git init` in an existing terminal tab.
+  useEffect(() => {
+    const interval = setInterval(() => {
+      const currentTabs = tabsRef.current;
+      const nonGitTabs = currentTabs.filter((t) => t.gitRoot === null);
+      for (const tab of nonGitTabs) {
+        getGitRepoInfo(tab.cwd).then((info) => {
+          if (info) {
+            setTabRepoInfo(tab.id, {
+              gitRoot: info.gitRoot,
+              repoName: info.repoName,
+              mainRepoRoot: info.mainRepoRoot ?? null,
+              worktreeName: info.worktreeName ?? null,
+            });
+          }
+        });
+      }
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [setTabRepoInfo]);
 }


### PR DESCRIPTION
## Summary
- Adds periodic polling (every 3s) in `useTabGitRoots` to re-check tabs where `gitRoot === null`, detecting `git init` in existing terminal tabs
- Updates `MainLayout` sync effect to re-fire when the active tab's `gitRoot` changes, triggering file tree and indexing updates
- Uses the already-resolved `gitRoot` directly instead of making a redundant async `getGitRoot` call

## Test plan
- [ ] Open Amend, create a new terminal
- [ ] Run `mkdir /tmp/test-repo && cd /tmp/test-repo` — should show under `~`
- [ ] Run `git init` — within a few seconds the tab should move from `~` to `test-repo`
- [ ] Run `git remote add origin https://github.com/test/test.git` — should remain under `test-repo`
- [ ] Verify the file browser updates to show the new repo's contents
- [ ] Verify existing behavior: opening a terminal in an already-git directory still works immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)