### PR TITLE
fix: increase drop zone overlay opacity for better visibility

### DIFF
--- a/src/components/Terminal/DropZoneOverlay.tsx
+++ b/src/components/Terminal/DropZoneOverlay.tsx
@@ -25,7 +25,7 @@ function DropPreview({ zone }: { zone: DropZone }) {
 
   return (
     <div
-      className={`absolute ${previewStyle[zone]} rounded-md bg-accent/15 border-2 border-accent/40 pointer-events-none transition-all duration-100`}
+      className={`absolute ${previewStyle[zone]} rounded-md bg-accent/25 border-2 border-accent/60 pointer-events-none transition-all duration-100`}
     />
   );
 }
@@ -119,7 +119,7 @@ export function DropZoneOverlay({ leafId }: DropZoneOverlayProps) {
       onMouseLeave={handleMouseLeave}
     >
       {/* Translucent scrim so the preview stands out */}
-      <div className="absolute inset-0 bg-black/10 pointer-events-none" />
+      <div className="absolute inset-0 bg-black/20 pointer-events-none" />
 
       {/* Placement preview */}
       <DropPreview zone={hoveredZone} />


### PR DESCRIPTION
## Summary
- Increased scrim opacity from 10% to 20% black
- Increased drop preview background opacity from 15% to 25% accent
- Increased drop preview border opacity from 40% to 60% accent

## Test plan
- Open multiple terminal tabs
- Drag a tab out of the tab bar to trigger split mode
- Confirm overlay zones are clearly visible when hovering over different regions (left, right, top, bottom, center)

🤖 Generated with [Claude Code](https://claude.com/claude-code)