### PR TITLE
fix: improve tab selection visibility with opacity on inactive tabs

### DIFF
--- a/src/components/FileBrowser/BrowseEditorTabs.tsx
+++ b/src/components/FileBrowser/BrowseEditorTabs.tsx
@@ -203,7 +203,7 @@ export const BrowseEditorTabs = forwardRef<BrowseEditorTabsHandle>(
                   className={`group flex items-center gap-1.5 px-2 py-1 text-xs ${
                     browseActiveFilePath === file.path
                       ? 'bg-surface-0 text-primary'
-                      : 'text-secondary hover:bg-surface-1'
+                      : 'text-secondary hover:bg-surface-1 opacity-50 hover:opacity-75'
                   } ${dragFromIndex === index ? 'opacity-50' : ''}`}
                 >
                   <StatusIndicator status={status} />

--- a/src/components/Terminal/TerminalLeafPane.tsx
+++ b/src/components/Terminal/TerminalLeafPane.tsx
@@ -125,7 +125,7 @@ export function TerminalLeafPane({ leafId, terminalIds, activeTerminalId }: Term
                 onMouseDown={(e) => handleTabMouseDown(e, tid)}
                 onClick={() => handleTabClick(tid)}
                 className={`group flex items-center gap-1 px-1.5 py-0.5 text-[11px] shrink-0 ${
-                  isActive ? 'bg-terminal-bg text-primary' : 'text-secondary hover:bg-surface-2'
+                  isActive ? 'bg-terminal-bg text-primary' : 'text-secondary hover:bg-surface-2 opacity-50 hover:opacity-75'
                 } ${draggingTabId === tid ? 'opacity-50' : ''}`}
               >
                 <TerminalTabLabel tab={tab} />

--- a/src/components/Terminal/TerminalTabs.tsx
+++ b/src/components/Terminal/TerminalTabs.tsx
@@ -299,7 +299,7 @@ export const TerminalTabs = forwardRef<TerminalTabsHandle>(function TerminalTabs
                             className={`group flex items-center gap-1.5 px-2 py-1 text-xs ${
                               isActive
                                 ? 'bg-terminal-bg text-primary'
-                                : 'text-secondary hover:bg-surface-1'
+                                : 'text-secondary hover:bg-surface-1 opacity-50 hover:opacity-75'
                             } ${dragFromIndex === globalIndex ? 'opacity-50' : ''}`}
                             title={tab.cwd}
                           >


### PR DESCRIPTION
## Summary
- Add `opacity-50` to inactive tabs across browse editor, terminal tabs, and terminal pane tabs so the active tab is clearly distinguishable
- Inactive tabs brighten to `opacity-75` on hover for feedback

## Test plan
- [ ] Open app with multiple browse tabs — active tab is full brightness, inactive tabs are dimmed
- [ ] Open multiple terminal tabs — same behavior
- [ ] Split terminal panes — pane tabs also show the distinction
- [ ] Hover inactive tabs — opacity increases from 50% to 75%

🤖 Generated with [Claude Code](https://claude.com/claude-code)