### PR TITLE
fix: show untracked files count in diff button

### DIFF
--- a/src/components/Layout/MainLayout.tsx
+++ b/src/components/Layout/MainLayout.tsx
@@ -158,6 +158,7 @@ export function MainLayout() {
   const restoredContextsRef = useRef<Set<string>>(new Set());
   const gitPolling = useGitPolling(contextPath);
   const diffStats = gitPolling.diffStats;
+  const gitStatus = gitPolling.status;
 
   // Centralized keyboard shortcuts
   useCommands({ terminalTabsRef, browseEditorTabsRef });
@@ -351,6 +352,13 @@ export function MainLayout() {
                       -{diffStats.deletions}
                     </span>
                   )}
+                </span>
+              )}
+              {gitStatus && gitStatus.untracked.length > 0 && (
+                <span
+                  className={`${diffStats && (diffStats.additions > 0 || diffStats.deletions > 0) ? 'ml-1' : 'ml-1.5'} ${panelMode === 'diff' ? 'text-white/80' : 'text-tertiary'}`}
+                >
+                  ?{gitStatus.untracked.length}
                 </span>
               )}
             </button>


### PR DESCRIPTION
## Summary
- Display a `?N` indicator in the toolbar's Diff button when untracked files exist
- Ensures users can see pending changes even when there are no staged/unstaged modifications
- Uses `text-tertiary` when inactive and `text-white/80` when active, matching existing indicator styling

## Test plan
- [ ] Open a git repo with only untracked files — the Diff button should show `?N`
- [ ] Open a git repo with both modifications and untracked files — should show `+N -M ?K`
- [ ] Open a git repo with no changes — no indicators shown
- [ ] Toggle the diff panel active/inactive and verify color contrast works for all indicators

🤖 Generated with [Claude Code](https://claude.com/claude-code)