### PR TITLE
fix: dim non-focused terminal panes in split layout

### DIFF
--- a/src/components/Terminal/TerminalLeafPane.tsx
+++ b/src/components/Terminal/TerminalLeafPane.tsx
@@ -110,7 +110,7 @@ export function TerminalLeafPane({ leafId, terminalIds, activeTerminalId }: Term
     <div
       className={`relative flex h-full w-full flex-col ${
         multipleVisible && isFocused ? 'ring-1 ring-inset ring-accent/50' : ''
-      }`}
+      } ${multipleVisible && !isFocused ? 'opacity-50' : ''}`}
       onMouseDown={handleMouseDown}
     >
       {showTabBar && (


### PR DESCRIPTION
## Summary
- Applies `opacity-50` to non-focused terminal panes when multiple panes are visible in split layout
- Makes the active/focused pane stand out more clearly
- Single-pane mode is unaffected

## Test plan
- [ ] Open the app, create a split terminal layout (2+ panes)
- [ ] Click between panes — unfocused pane(s) should dim, focused one stays fully opaque
- [ ] Verify single-pane mode has no dimming

🤖 Generated with [Claude Code](https://claude.com/claude-code)