### PR TITLE
fix: allow terminal drag-and-drop to create additional full-height columns

### DIFF
--- a/src/components/Terminal/DropZoneOverlay.tsx
+++ b/src/components/Terminal/DropZoneOverlay.tsx
@@ -33,11 +33,11 @@ function DropPreview({ zone }: { zone: DropZone }) {
 export function DropZoneOverlay({ leafId }: DropZoneOverlayProps) {
   const isDragging = useTerminalDragStore((s) => s.isDragging);
   const draggedTerminalId = useTerminalDragStore((s) => s.draggedTerminalId);
+  const rootDropActive = useTerminalDragStore((s) => s.rootDropActive);
   const endDrag = useTerminalDragStore((s) => s.endDrag);
-  const splitPane = useTerminalLayoutStore((s) => s.splitPane);
+  const moveTerminalToSplit = useTerminalLayoutStore((s) => s.moveTerminalToSplit);
   const assignTerminalToPane = useTerminalLayoutStore((s) => s.assignTerminalToPane);
   const layout = useTerminalLayoutStore((s) => s.layout);
-  const removeFromLayout = useTerminalLayoutStore((s) => s.removeFromLayout);
 
   const [hoveredZone, setHoveredZone] = useState<DropZone>(null);
 
@@ -86,11 +86,8 @@ export function DropZoneOverlay({ leafId }: DropZoneOverlayProps) {
       const side: 'first' | 'second' =
         hoveredZone === 'left' || hoveredZone === 'top' ? 'first' : 'second';
 
-      // Remove from old position if it was in layout
-      if (layout && findLeafByTerminalId(layout, draggedTerminalId)) {
-        removeFromLayout(draggedTerminalId);
-      }
-      splitPane(leafId, direction, side, draggedTerminalId);
+      // Atomic: remove from source + split target in one operation
+      moveTerminalToSplit(draggedTerminalId, leafId, direction, side);
     }
 
     endDrag();
@@ -99,9 +96,8 @@ export function DropZoneOverlay({ leafId }: DropZoneOverlayProps) {
     hoveredZone,
     leafId,
     layout,
-    splitPane,
+    moveTerminalToSplit,
     assignTerminalToPane,
-    removeFromLayout,
     endDrag,
   ]);
 
@@ -109,7 +105,7 @@ export function DropZoneOverlay({ leafId }: DropZoneOverlayProps) {
     setHoveredZone(null);
   }, []);
 
-  if (!isDragging) return null;
+  if (!isDragging || rootDropActive) return null;
 
   return (
     <div

--- a/src/components/Terminal/RootDropZone.tsx
+++ b/src/components/Terminal/RootDropZone.tsx
@@ -1,0 +1,104 @@
+import { useState, useCallback, type ReactNode } from 'react';
+import { useTerminalDragStore } from '@/stores/terminalDragStore';
+import { useTerminalLayoutStore } from '@/stores/terminalLayoutStore';
+import { collectLeaves } from '@/lib/layoutTree';
+
+type RootEdge = 'left' | 'right' | 'top' | 'bottom';
+
+interface RootDropZoneProps {
+  children: ReactNode;
+}
+
+function RootEdgeStrip({ edge, onDrop }: { edge: RootEdge; onDrop: (edge: RootEdge) => void }) {
+  const [hovered, setHovered] = useState(false);
+  const setRootDropActive = useTerminalDragStore((s) => s.setRootDropActive);
+
+  const handleMouseEnter = useCallback(() => {
+    setHovered(true);
+    setRootDropActive(true);
+  }, [setRootDropActive]);
+
+  const handleMouseLeave = useCallback(() => {
+    setHovered(false);
+    setRootDropActive(false);
+  }, [setRootDropActive]);
+
+  const handleMouseUp = useCallback(() => {
+    onDrop(edge);
+    setHovered(false);
+    setRootDropActive(false);
+  }, [edge, onDrop, setRootDropActive]);
+
+  const stripClass: Record<RootEdge, string> = {
+    left: 'left-0 top-0 bottom-0 w-12',
+    right: 'right-0 top-0 bottom-0 w-12',
+    top: 'left-0 top-0 right-0 h-12',
+    bottom: 'left-0 bottom-0 right-0 h-12',
+  };
+
+  const previewClass: Record<RootEdge, string> = {
+    left: 'left-0 top-0 bottom-0 w-1/3',
+    right: 'right-0 top-0 bottom-0 w-1/3',
+    top: 'left-0 top-0 right-0 h-1/3',
+    bottom: 'left-0 bottom-0 right-0 h-1/3',
+  };
+
+  return (
+    <>
+      <div
+        className={`absolute ${stripClass[edge]} z-30`}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        onMouseUp={handleMouseUp}
+      />
+      {hovered && (
+        <div
+          className={`absolute ${previewClass[edge]} z-[25] rounded-md bg-accent/25 border-2 border-accent/60 pointer-events-none`}
+        />
+      )}
+    </>
+  );
+}
+
+export function RootDropZone({ children }: RootDropZoneProps) {
+  const isDragging = useTerminalDragStore((s) => s.isDragging);
+  const draggedTerminalId = useTerminalDragStore((s) => s.draggedTerminalId);
+  const endDrag = useTerminalDragStore((s) => s.endDrag);
+  const layout = useTerminalLayoutStore((s) => s.layout);
+  const splitAtRoot = useTerminalLayoutStore((s) => s.splitAtRoot);
+
+  const leafCount = layout ? collectLeaves(layout).length : 0;
+  const showRootDropZones = isDragging && leafCount > 1;
+
+  const handleDrop = useCallback(
+    (edge: RootEdge) => {
+      if (!draggedTerminalId) {
+        endDrag();
+        return;
+      }
+
+      const direction: 'horizontal' | 'vertical' =
+        edge === 'left' || edge === 'right' ? 'horizontal' : 'vertical';
+      const side: 'first' | 'second' =
+        edge === 'left' || edge === 'top' ? 'first' : 'second';
+
+      splitAtRoot(direction, side, draggedTerminalId);
+      endDrag();
+    },
+    [draggedTerminalId, splitAtRoot, endDrag]
+  );
+
+  return (
+    <div className="relative w-full h-full">
+      {children}
+      {showRootDropZones && (
+        <>
+          <RootEdgeStrip edge="left" onDrop={handleDrop} />
+          <RootEdgeStrip edge="right" onDrop={handleDrop} />
+          <RootEdgeStrip edge="top" onDrop={handleDrop} />
+          <RootEdgeStrip edge="bottom" onDrop={handleDrop} />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/Terminal/TerminalTabs.tsx
+++ b/src/components/Terminal/TerminalTabs.tsx
@@ -17,6 +17,7 @@ import { useCreateTerminal, useCloseTerminal } from '@/hooks/useTerminalLifecycl
 import { useTabGitRoots } from '@/hooks/useTabGitRoots';
 import { TerminalPane } from './TerminalPane';
 import { TerminalSplitLayout } from './TerminalSplitLayout';
+import { RootDropZone } from './RootDropZone';
 import { CloseIcon, FolderIcon } from '@/components/Icons';
 import { getFileName, formatShortcut } from '@/lib/fileUtils';
 import { useDraggableTabs } from '@/hooks/useDraggableTabs';
@@ -344,7 +345,11 @@ export const TerminalTabs = forwardRef<TerminalTabsHandle>(function TerminalTabs
           />
         )}
         {/* Render split layout for visible terminals */}
-        {layout && <TerminalSplitLayout node={layout} />}
+        {layout && (
+          <RootDropZone>
+            <TerminalSplitLayout node={layout} />
+          </RootDropZone>
+        )}
         {/* Keep backgrounded terminals hidden-mounted to preserve xterm state */}
         {tabs
           .filter((tab) => !visibleTerminalIds.has(tab.id))

--- a/src/stores/terminalDragStore.ts
+++ b/src/stores/terminalDragStore.ts
@@ -4,21 +4,28 @@ interface TerminalDragState {
   isDragging: boolean;
   draggedTerminalId: string | null;
   dragSourceLeafId: string | null;
+  rootDropActive: boolean;
 
   startDrag: (terminalId: string, sourceLeafId?: string | null) => void;
   endDrag: () => void;
+  setRootDropActive: (active: boolean) => void;
 }
 
 export const useTerminalDragStore = create<TerminalDragState>((set) => ({
   isDragging: false,
   draggedTerminalId: null,
   dragSourceLeafId: null,
+  rootDropActive: false,
 
   startDrag: (terminalId, sourceLeafId = null) => {
     set({ isDragging: true, draggedTerminalId: terminalId, dragSourceLeafId: sourceLeafId });
   },
 
   endDrag: () => {
-    set({ isDragging: false, draggedTerminalId: null, dragSourceLeafId: null });
+    set({ isDragging: false, draggedTerminalId: null, dragSourceLeafId: null, rootDropActive: false });
+  },
+
+  setRootDropActive: (active) => {
+    set({ rootDropActive: active });
   },
 }));

--- a/src/stores/terminalLayoutStore.ts
+++ b/src/stores/terminalLayoutStore.ts
@@ -30,6 +30,17 @@ interface TerminalLayoutState {
   ensureTerminalInLayout: (terminalId: string) => void;
   setActiveTerminalInPane: (leafId: string, terminalId: string) => void;
   moveTerminalToPane: (terminalId: string, targetLeafId: string) => void;
+  moveTerminalToSplit: (
+    terminalId: string,
+    targetLeafId: string,
+    direction: 'horizontal' | 'vertical',
+    side: 'first' | 'second'
+  ) => void;
+  splitAtRoot: (
+    direction: 'horizontal' | 'vertical',
+    side: 'first' | 'second',
+    terminalId: string
+  ) => void;
 }
 
 export const useTerminalLayoutStore = create<TerminalLayoutState>((set, get) => ({
@@ -186,6 +197,94 @@ export const useTerminalLayoutStore = create<TerminalLayoutState>((set, get) => 
   moveTerminalToPane: (terminalId: string, targetLeafId: string) => {
     const { assignTerminalToPane } = get();
     assignTerminalToPane(targetLeafId, terminalId);
+  },
+
+  moveTerminalToSplit: (terminalId, targetLeafId, direction, side) => {
+    let { layout } = get();
+    if (!layout) return;
+
+    const sourceLeaf = findLeafByTerminalId(layout, terminalId);
+
+    // Guard: self-split of a single-terminal pane is a no-op
+    if (sourceLeaf && sourceLeaf.id === targetLeafId && sourceLeaf.type === 'leaf' && sourceLeaf.terminalIds.length === 1) {
+      return;
+    }
+
+    // Remove terminal from its current position (if any)
+    if (sourceLeaf) {
+      const afterRemove = removeLeaf(layout, terminalId);
+      if (!afterRemove) {
+        // Layout collapsed entirely — just create a single leaf
+        const leaf = makeLeaf(terminalId);
+        set({ layout: leaf, focusedPaneId: leaf.id });
+        useTerminalStore.getState().setActiveTab(terminalId);
+        return;
+      }
+      layout = afterRemove;
+    }
+
+    // Try to find target leaf in the (possibly restructured) layout
+    const target = findNode(layout, targetLeafId);
+    if (target && target.type === 'leaf') {
+      // Target still exists — split it normally
+      const newLeaf = makeLeaf(terminalId);
+      const splitNode: LayoutNode = {
+        type: 'split',
+        id: genNodeId(),
+        direction,
+        first: side === 'first' ? newLeaf : target,
+        second: side === 'second' ? newLeaf : target,
+        ratio: 50,
+      };
+      const newLayout = replaceNode(layout, targetLeafId, splitNode);
+      set({ layout: newLayout, focusedPaneId: newLeaf.id });
+      useTerminalStore.getState().setActiveTab(terminalId);
+    } else {
+      // Target was lost (collapsed when source was removed) — wrap at root
+      const newLeaf = makeLeaf(terminalId);
+      const newLayout: LayoutNode = {
+        type: 'split',
+        id: genNodeId(),
+        direction,
+        first: side === 'first' ? newLeaf : layout,
+        second: side === 'second' ? newLeaf : layout,
+        ratio: 50,
+      };
+      set({ layout: newLayout, focusedPaneId: newLeaf.id });
+      useTerminalStore.getState().setActiveTab(terminalId);
+    }
+  },
+
+  splitAtRoot: (direction, side, terminalId) => {
+    let { layout } = get();
+    if (!layout) return;
+
+    // Remove terminal from current position if in layout
+    const sourceLeaf = findLeafByTerminalId(layout, terminalId);
+    if (sourceLeaf) {
+      const afterRemove = removeLeaf(layout, terminalId);
+      if (!afterRemove) {
+        // Layout collapsed — just create a single leaf
+        const leaf = makeLeaf(terminalId);
+        set({ layout: leaf, focusedPaneId: leaf.id });
+        useTerminalStore.getState().setActiveTab(terminalId);
+        return;
+      }
+      layout = afterRemove;
+    }
+
+    // Wrap the entire remaining layout in a new root-level split
+    const newLeaf = makeLeaf(terminalId);
+    const newLayout: LayoutNode = {
+      type: 'split',
+      id: genNodeId(),
+      direction,
+      first: side === 'first' ? newLeaf : layout,
+      second: side === 'second' ? newLeaf : layout,
+      ratio: 50,
+    };
+    set({ layout: newLayout, focusedPaneId: newLeaf.id });
+    useTerminalStore.getState().setActiveTab(terminalId);
   },
 
   ensureTerminalInLayout: (terminalId: string) => {


### PR DESCRIPTION
## Summary
- Add atomic `moveTerminalToSplit` store action that removes a terminal from its source pane and splits the target in one operation, preventing layout corruption when dragging the sole terminal out of a pane
- Add `splitAtRoot` store action and `RootDropZone` component with edge strips so users can create full-height columns at the root of the layout tree
- Add `rootDropActive` flag to suppress leaf-level drop zones while hovering root edges

## Test plan
- [ ] Start with 1 terminal, Cmd+T for a 2nd, drag to right edge to split into 2 columns
- [ ] Cmd+T for a 3rd terminal, drag to the far-right edge of the container — should create a 3rd full-height column at root level
- [ ] Drag a terminal that is the only one in its pane to the same pane's edge — should no-op
- [ ] Drag from one pane to another pane's edge — should work as before (leaf-level split)
- [ ] With a vertical split layout, drag to the far-right edge — should create a full-height column at root level

🤖 Generated with [Claude Code](https://claude.com/claude-code)