### PR TITLE
fix: show .env files in file browser

### DIFF
--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -210,6 +210,8 @@ impl FileSystemManager {
             .max_depth(Some(1))
             .hidden(false)
             .git_ignore(false)
+            .git_global(false)
+            .git_exclude(false)
             .build();
 
         for entry in walker.flatten() {


### PR DESCRIPTION
## Summary
- Disable `git_global` and `git_exclude` filters on the `WalkBuilder` in `read_directory()` so `.env` files (and other globally ignored files) appear in the file browser

## Test plan
- [ ] Open a project that contains a `.env` file
- [ ] Verify the `.env` file appears in the file browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)