### PR TITLE
feat: add MCP registration support for multiple AI tools

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,6 +45,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors"] }
 futures-util = "0.3"
 async-stream = "0.3"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -82,6 +82,7 @@ pub fn run() {
             // MCP commands
             mcp::get_mcp_server_port,
             mcp::register_mcp_server,
+            mcp::check_mcp_registrations,
             // Terminal metadata commands
             terminal_metadata::sync_terminal_metadata,
             terminal_metadata::remove_terminal_metadata,

--- a/src-tauri/src/mcp.rs
+++ b/src-tauri/src/mcp.rs
@@ -431,40 +431,71 @@ fn discovery_file_path() -> Option<std::path::PathBuf> {
     dirs::home_dir().map(|h| h.join(".amend").join("mcp.json"))
 }
 
-fn claude_code_config_path() -> Option<std::path::PathBuf> {
-    dirs::home_dir().map(|h| h.join(".claude.json"))
+// --- Multi-tool MCP registration ---
+
+struct JsonMcpTool {
+    name: &'static str,
+    config_path: fn() -> Option<std::path::PathBuf>,
+    url_field: &'static str,
+    extra_fields: Option<Value>,
 }
 
-fn write_discovery_file(port: u16) {
-    if let Some(path) = discovery_file_path() {
-        if let Some(parent) = path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let content = json!({
-            "url": format!("http://127.0.0.1:{}/sse", port)
-        });
-        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
-            eprintln!("[MCP] Failed to write discovery file: {}", e);
-        }
-    }
+const MCP_SERVER_KEY: &str = "amend-terminal";
 
-    write_claude_code_config(port);
+fn json_mcp_tools() -> Vec<JsonMcpTool> {
+    vec![
+        JsonMcpTool {
+            name: "Claude Code",
+            config_path: || dirs::home_dir().map(|h| h.join(".claude.json")),
+            url_field: "url",
+            extra_fields: Some(json!({"type": "sse"})),
+        },
+        JsonMcpTool {
+            name: "Cursor",
+            config_path: || dirs::home_dir().map(|h| h.join(".cursor").join("mcp.json")),
+            url_field: "url",
+            extra_fields: None,
+        },
+        JsonMcpTool {
+            name: "Windsurf",
+            config_path: || {
+                dirs::home_dir()
+                    .map(|h| h.join(".codeium").join("windsurf").join("mcp_config.json"))
+            },
+            url_field: "serverUrl",
+            extra_fields: None,
+        },
+        JsonMcpTool {
+            name: "Cline",
+            config_path: || {
+                dirs::home_dir().map(|h| {
+                    h.join("Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json")
+                })
+            },
+            url_field: "url",
+            extra_fields: None,
+        },
+        JsonMcpTool {
+            name: "Gemini CLI",
+            config_path: || dirs::home_dir().map(|h| h.join(".gemini").join("settings.json")),
+            url_field: "url",
+            extra_fields: None,
+        },
+    ]
 }
 
-pub fn remove_discovery_file(port: Option<u16>) {
-    if let Some(path) = discovery_file_path() {
-        let _ = std::fs::remove_file(path);
-    }
-
-    if let Some(port) = port {
-        remove_claude_code_config(port);
-    }
+fn sse_url(port: u16) -> String {
+    format!("http://127.0.0.1:{}/sse", port)
 }
 
-fn write_claude_code_config(port: u16) {
-    let Some(path) = claude_code_config_path() else {
+fn write_json_tool_config(tool: &JsonMcpTool, port: u16) {
+    let Some(path) = (tool.config_path)() else {
         return;
     };
+
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
 
     let mut config: Value = std::fs::read_to_string(&path)
         .ok()
@@ -479,27 +510,30 @@ fn write_claude_code_config(port: u16) {
     let servers = obj.entry("mcpServers").or_insert_with(|| json!({}));
 
     if let Some(servers_obj) = servers.as_object_mut() {
-        servers_obj.insert(
-            "amend-terminal".to_string(),
-            json!({
-                "type": "sse",
-                "url": format!("http://127.0.0.1:{}/sse", port)
-            }),
-        );
+        let mut entry = json!({});
+        entry[tool.url_field] = json!(sse_url(port));
+        if let Some(extra) = &tool.extra_fields {
+            if let (Some(entry_obj), Some(extra_obj)) = (entry.as_object_mut(), extra.as_object()) {
+                for (k, v) in extra_obj {
+                    entry_obj.insert(k.clone(), v.clone());
+                }
+            }
+        }
+        servers_obj.insert(MCP_SERVER_KEY.to_string(), entry);
     }
 
     match serde_json::to_string_pretty(&config) {
         Ok(json_str) => {
             if let Err(e) = std::fs::write(&path, json_str) {
-                eprintln!("[MCP] Failed to write Claude Code config: {}", e);
+                eprintln!("[MCP] Failed to write {} config: {}", tool.name, e);
             }
         }
-        Err(e) => eprintln!("[MCP] Failed to serialize Claude Code config: {}", e),
+        Err(e) => eprintln!("[MCP] Failed to serialize {} config: {}", tool.name, e),
     }
 }
 
-fn remove_claude_code_config(port: u16) {
-    let Some(path) = claude_code_config_path() else {
+fn remove_json_tool_config(tool: &JsonMcpTool, port: u16) {
+    let Some(path) = (tool.config_path)() else {
         return;
     };
 
@@ -524,11 +558,10 @@ fn remove_claude_code_config(port: u16) {
             None => return,
         };
 
-        // Only remove if the URL matches our port
-        let expected_url = format!("http://127.0.0.1:{}/sse", port);
-        if let Some(entry) = servers.get("amend-terminal") {
-            if entry.get("url").and_then(|u| u.as_str()) == Some(&expected_url) {
-                servers.remove("amend-terminal");
+        let expected_url = sse_url(port);
+        if let Some(entry) = servers.get(MCP_SERVER_KEY) {
+            if entry.get(tool.url_field).and_then(|u| u.as_str()) == Some(&expected_url) {
+                servers.remove(MCP_SERVER_KEY);
             }
         }
 
@@ -542,10 +575,208 @@ fn remove_claude_code_config(port: u16) {
     match serde_json::to_string_pretty(&config) {
         Ok(json_str) => {
             if let Err(e) = std::fs::write(&path, json_str) {
-                eprintln!("[MCP] Failed to write Claude Code config: {}", e);
+                eprintln!("[MCP] Failed to write {} config: {}", tool.name, e);
             }
         }
-        Err(e) => eprintln!("[MCP] Failed to serialize Claude Code config: {}", e),
+        Err(e) => eprintln!("[MCP] Failed to serialize {} config: {}", tool.name, e),
+    }
+}
+
+fn check_json_tool_registered(tool: &JsonMcpTool, port: u16) -> bool {
+    let Some(path) = (tool.config_path)() else {
+        return false;
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    let config: Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return false,
+    };
+
+    let expected_url = sse_url(port);
+    config
+        .get("mcpServers")
+        .and_then(|s| s.get(MCP_SERVER_KEY))
+        .and_then(|e| e.get(tool.url_field))
+        .and_then(|u| u.as_str())
+        == Some(&expected_url)
+}
+
+// --- Codex CLI (TOML) ---
+
+fn codex_config_path() -> Option<std::path::PathBuf> {
+    dirs::home_dir().map(|h| h.join(".codex").join("config.toml"))
+}
+
+fn write_codex_config(port: u16) {
+    let Some(path) = codex_config_path() else {
+        return;
+    };
+
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    let mut config: toml::Table = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or_default();
+
+    let servers = config
+        .entry("mcp_servers")
+        .or_insert_with(|| toml::Value::Table(toml::Table::new()));
+
+    if let toml::Value::Table(servers_tbl) = servers {
+        let mut entry = toml::Table::new();
+        entry.insert("url".to_string(), toml::Value::String(sse_url(port)));
+        servers_tbl.insert(MCP_SERVER_KEY.to_string(), toml::Value::Table(entry));
+    }
+
+    match toml::to_string_pretty(&config) {
+        Ok(toml_str) => {
+            if let Err(e) = std::fs::write(&path, toml_str) {
+                eprintln!("[MCP] Failed to write Codex CLI config: {}", e);
+            }
+        }
+        Err(e) => eprintln!("[MCP] Failed to serialize Codex CLI config: {}", e),
+    }
+}
+
+fn remove_codex_config(port: u16) {
+    let Some(path) = codex_config_path() else {
+        return;
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let mut config: toml::Table = match content.parse() {
+        Ok(t) => t,
+        Err(_) => return,
+    };
+
+    let should_remove_servers = {
+        let servers = match config.get_mut("mcp_servers") {
+            Some(toml::Value::Table(t)) => t,
+            _ => return,
+        };
+
+        let expected_url = sse_url(port);
+        if let Some(toml::Value::Table(entry)) = servers.get(MCP_SERVER_KEY) {
+            if entry.get("url").and_then(|u| u.as_str()) == Some(expected_url.as_str()) {
+                servers.remove(MCP_SERVER_KEY);
+            }
+        }
+
+        servers.is_empty()
+    };
+
+    if should_remove_servers {
+        config.remove("mcp_servers");
+    }
+
+    match toml::to_string_pretty(&config) {
+        Ok(toml_str) => {
+            if let Err(e) = std::fs::write(&path, toml_str) {
+                eprintln!("[MCP] Failed to write Codex CLI config: {}", e);
+            }
+        }
+        Err(e) => eprintln!("[MCP] Failed to serialize Codex CLI config: {}", e),
+    }
+}
+
+fn check_codex_registered(port: u16) -> bool {
+    let Some(path) = codex_config_path() else {
+        return false;
+    };
+
+    let content = match std::fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+
+    let config: toml::Table = match content.parse() {
+        Ok(t) => t,
+        Err(_) => return false,
+    };
+
+    let expected_url = sse_url(port);
+    config
+        .get("mcp_servers")
+        .and_then(|s| s.get(MCP_SERVER_KEY))
+        .and_then(|e| e.get("url"))
+        .and_then(|u| u.as_str())
+        == Some(expected_url.as_str())
+}
+
+// --- Aggregate write/remove/check ---
+
+fn write_all_tool_configs(port: u16) {
+    for tool in &json_mcp_tools() {
+        write_json_tool_config(tool, port);
+    }
+    write_codex_config(port);
+}
+
+fn remove_all_tool_configs(port: u16) {
+    for tool in &json_mcp_tools() {
+        remove_json_tool_config(tool, port);
+    }
+    remove_codex_config(port);
+}
+
+#[derive(Debug, Serialize, Clone)]
+pub struct McpToolRegistration {
+    pub name: String,
+    pub registered: bool,
+}
+
+fn check_all_tool_registrations(port: u16) -> Vec<McpToolRegistration> {
+    let mut results: Vec<McpToolRegistration> = json_mcp_tools()
+        .iter()
+        .map(|tool| McpToolRegistration {
+            name: tool.name.to_string(),
+            registered: check_json_tool_registered(tool, port),
+        })
+        .collect();
+
+    results.push(McpToolRegistration {
+        name: "Codex CLI".to_string(),
+        registered: check_codex_registered(port),
+    });
+
+    results
+}
+
+fn write_discovery_file(port: u16) {
+    if let Some(path) = discovery_file_path() {
+        if let Some(parent) = path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+        let content = json!({
+            "url": sse_url(port)
+        });
+        if let Err(e) = std::fs::write(&path, serde_json::to_string_pretty(&content).unwrap()) {
+            eprintln!("[MCP] Failed to write discovery file: {}", e);
+        }
+    }
+
+    write_all_tool_configs(port);
+}
+
+pub fn remove_discovery_file(port: Option<u16>) {
+    if let Some(path) = discovery_file_path() {
+        let _ = std::fs::remove_file(path);
+    }
+
+    if let Some(port) = port {
+        remove_all_tool_configs(port);
     }
 }
 
@@ -582,6 +813,14 @@ pub async fn get_mcp_server_port(
 #[tauri::command]
 pub async fn register_mcp_server(state: tauri::State<'_, McpServerHandle>) -> Result<(), String> {
     let port = state.get_port().await.ok_or("MCP server not running")?;
-    write_claude_code_config(port);
+    write_all_tool_configs(port);
     Ok(())
+}
+
+#[tauri::command]
+pub async fn check_mcp_registrations(
+    state: tauri::State<'_, McpServerHandle>,
+) -> Result<Vec<McpToolRegistration>, String> {
+    let port = state.get_port().await.ok_or("MCP server not running")?;
+    Ok(check_all_tool_registrations(port))
 }

--- a/src/components/Settings/SettingsPanel.tsx
+++ b/src/components/Settings/SettingsPanel.tsx
@@ -54,7 +54,10 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
             <h3 className="mb-2 text-xs font-medium text-secondary">Language Servers</h3>
             <div className="space-y-2">
               {lspStatuses.map(({ config, running }) => (
-                <div key={config.name} className="flex items-center justify-between rounded-md bg-surface-3 px-3 py-2">
+                <div
+                  key={config.name}
+                  className="flex items-center justify-between rounded-md bg-surface-3 px-3 py-2"
+                >
                   <div>
                     <div className="text-xs font-medium text-primary">{config.name}</div>
                     <div className="text-[10px] text-tertiary">
@@ -62,9 +65,13 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
                     </div>
                   </div>
                   <div className="flex items-center gap-1.5">
-                    <span className={`inline-block h-1.5 w-1.5 rounded-full ${running ? 'bg-green-500' : 'bg-gray-400'}`} />
+                    <span
+                      className={`inline-block h-1.5 w-1.5 rounded-full ${running ? 'bg-green-500' : 'bg-gray-400'}`}
+                    />
                     <span className="text-[10px] text-secondary">
-                      {running ? `Running (${running.refCount} ${running.refCount === 1 ? 'file' : 'files'})` : 'Stopped'}
+                      {running
+                        ? `Running (${running.refCount} ${running.refCount === 1 ? 'file' : 'files'})`
+                        : 'Stopped'}
                     </span>
                   </div>
                 </div>
@@ -80,7 +87,9 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
             <div className="space-y-2 rounded-md bg-surface-3 px-3 py-2">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-1.5">
-                  <span className={`inline-block h-1.5 w-1.5 rounded-full ${mcpStatus.port ? 'bg-green-500' : 'bg-gray-400'}`} />
+                  <span
+                    className={`inline-block h-1.5 w-1.5 rounded-full ${mcpStatus.port ? 'bg-green-500' : 'bg-gray-400'}`}
+                  />
                   <span className="text-xs font-medium text-primary">{mcpServerName}</span>
                 </div>
                 {mcpStatus.port && (
@@ -95,27 +104,44 @@ export function SettingsPanel({ onClose }: { onClose: () => void }) {
                 <span className="text-tertiary">Protocol</span>
                 <span className="text-secondary">{mcpProtocolVersion}</span>
               </div>
-              <div className="flex items-center justify-between text-[10px]">
-                <span className="text-tertiary">Claude Code</span>
-                <div className="flex items-center gap-2">
-                  <span className={mcpStatus.registered ? 'text-green-500' : 'text-secondary'}>
-                    {mcpStatus.registered ? 'Registered' : 'Not registered'}
-                  </span>
-                  {mcpStatus.port && !mcpStatus.registered && (
-                    <button
-                      onClick={() => registerMcpServer()}
-                      className="rounded bg-accent px-1.5 py-0.5 text-[10px] text-white hover:bg-accent/80"
-                    >
-                      Install
-                    </button>
-                  )}
+              {mcpStatus.registrations.length > 0 && (
+                <div>
+                  <div className="mb-1 flex items-center justify-between">
+                    <span className="text-[10px] text-tertiary">Registrations</span>
+                    {mcpStatus.port && mcpStatus.registrations.some((r) => !r.registered) && (
+                      <button
+                        onClick={() => registerMcpServer()}
+                        className="rounded bg-accent px-1.5 py-0.5 text-[10px] text-white hover:bg-accent/80"
+                      >
+                        Install All
+                      </button>
+                    )}
+                  </div>
+                  <div className="space-y-1">
+                    {mcpStatus.registrations.map((reg) => (
+                      <div key={reg.name} className="flex items-center justify-between text-[10px]">
+                        <span className="text-tertiary">{reg.name}</span>
+                        <div className="flex items-center gap-1.5">
+                          <span
+                            className={`inline-block h-1.5 w-1.5 rounded-full ${reg.registered ? 'bg-green-500' : 'bg-gray-400'}`}
+                          />
+                          <span className={reg.registered ? 'text-green-500' : 'text-secondary'}>
+                            {reg.registered ? 'Registered' : 'Not registered'}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
                 </div>
-              </div>
+              )}
               <div>
                 <div className="mb-1 text-[10px] text-tertiary">Tools</div>
                 <div className="flex flex-wrap gap-1">
                   {mcpTools.map((tool) => (
-                    <span key={tool} className="rounded bg-surface-1 px-1.5 py-0.5 text-[10px] text-secondary">
+                    <span
+                      key={tool}
+                      className="rounded bg-surface-1 px-1.5 py-0.5 text-[10px] text-secondary"
+                    >
                       {tool}
                     </span>
                   ))}

--- a/src/hooks/useServerStatus.ts
+++ b/src/hooks/useServerStatus.ts
@@ -1,8 +1,7 @@
 import { useState, useEffect } from 'react';
 import { getRunningServers, type LspServerStatus } from '@/lsp/manager';
 import { serverConfigs, type LspServerConfig } from '@/lsp/serverConfig';
-import { getMcpServerPort, readFile } from '@/lib/tauri';
-import { homeDir } from '@tauri-apps/api/path';
+import { getMcpServerPort, checkMcpRegistrations, type McpToolRegistration } from '@/lib/tauri';
 
 export interface LspConfigStatus {
   config: LspServerConfig;
@@ -11,16 +10,21 @@ export interface LspConfigStatus {
 
 export interface McpStatus {
   port: number | null;
-  registered: boolean;
+  registrations: McpToolRegistration[];
 }
 
-const MCP_TOOLS = ['list_terminals', 'read_terminal_output', 'is_terminal_busy', 'write_to_terminal'];
+const MCP_TOOLS = [
+  'list_terminals',
+  'read_terminal_output',
+  'is_terminal_busy',
+  'write_to_terminal',
+];
 const MCP_SERVER_NAME = 'amend-terminal-mcp';
 const MCP_PROTOCOL_VERSION = '2024-11-05';
 
 export function useServerStatus() {
   const [lspStatuses, setLspStatuses] = useState<LspConfigStatus[]>([]);
-  const [mcpStatus, setMcpStatus] = useState<McpStatus>({ port: null, registered: false });
+  const [mcpStatus, setMcpStatus] = useState<McpStatus>({ port: null, registrations: [] });
 
   useEffect(() => {
     function refresh() {
@@ -34,22 +38,15 @@ export function useServerStatus() {
 
     async function refreshMcp() {
       const port = await getMcpServerPort().catch(() => null);
-      let registered = false;
-      try {
-        const home = await homeDir();
-        const content = await readFile(`${home}.claude.json`);
-        const parsed = JSON.parse(content);
-        const servers = parsed?.mcpServers ?? {};
-        registered = Object.values(servers as Record<string, { url?: string }>).some(
-          (s) =>
-            typeof s?.url === 'string' &&
-            (s.url.includes('localhost') || s.url.includes('127.0.0.1')) &&
-            s.url.includes(String(port))
-        );
-      } catch {
-        // File doesn't exist or can't be parsed
+      let registrations: McpToolRegistration[] = [];
+      if (port) {
+        try {
+          registrations = await checkMcpRegistrations();
+        } catch {
+          // Server might not be ready yet
+        }
       }
-      setMcpStatus({ port, registered });
+      setMcpStatus({ port, registrations });
     }
 
     refresh();
@@ -63,5 +60,11 @@ export function useServerStatus() {
     return () => clearInterval(interval);
   }, []);
 
-  return { lspStatuses, mcpStatus, mcpTools: MCP_TOOLS, mcpServerName: MCP_SERVER_NAME, mcpProtocolVersion: MCP_PROTOCOL_VERSION };
+  return {
+    lspStatuses,
+    mcpStatus,
+    mcpTools: MCP_TOOLS,
+    mcpServerName: MCP_SERVER_NAME,
+    mcpProtocolVersion: MCP_PROTOCOL_VERSION,
+  };
 }

--- a/src/lib/tauri.ts
+++ b/src/lib/tauri.ts
@@ -72,6 +72,15 @@ export async function registerMcpServer(): Promise<void> {
   return invoke('register_mcp_server');
 }
 
+export interface McpToolRegistration {
+  name: string;
+  registered: boolean;
+}
+
+export async function checkMcpRegistrations(): Promise<McpToolRegistration[]> {
+  return invoke('check_mcp_registrations');
+}
+
 export async function onWindowCloseRequested(callback: () => void): Promise<UnlistenFn> {
   return listen('window-close-requested', () => {
     callback();


### PR DESCRIPTION
## Summary
- Register the MCP server with Claude Code, Cursor, Windsurf, Cline, Gemini CLI, and Codex CLI (previously only Claude Code)
- Add `check_mcp_registrations` Tauri command to report per-tool registration status
- Update settings panel to show individual tool registration status with dot indicators and an "Install All" button
- Add `toml` crate for Codex CLI config support

## Test plan
- [ ] Open settings panel and verify all 6 tools appear under Registrations
- [ ] Click "Install All" and verify status updates to registered for each tool
- [ ] Restart app and verify registrations persist
- [ ] Verify Codex CLI TOML config is written correctly at `~/.codex/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)