### PR TITLE
fix(worktree): place new worktree tab in focused pane immediately

### DIFF
--- a/src/components/WorktreeManager.tsx
+++ b/src/components/WorktreeManager.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/tauri';
 import { BranchIcon, CloseIcon, PlusIcon, TrashIcon, SpinnerIcon } from '@/components/Icons';
 import { getFileName } from '@/lib/fileUtils';
+import { useTerminalLayoutStore } from '@/stores/terminalLayoutStore';
 
 interface WorktreeManagerProps {
   repoPath: string;
@@ -46,17 +47,30 @@ export function WorktreeManager({
     refresh();
   }, [refresh]);
 
+  const openTerminalWithPaneAssignment = async (path: string) => {
+    try {
+      const newId = await createTerminal(path);
+      const { focusedPaneId, assignTerminalToPane } = useTerminalLayoutStore.getState();
+      if (focusedPaneId) {
+        assignTerminalToPane(focusedPaneId, newId);
+      }
+    } catch (err) {
+      console.error('Failed to create terminal:', err);
+    }
+  };
+
   const handleRowClick = async (wt: GitWorktree) => {
-    await createTerminal(wt.path);
+    await openTerminalWithPaneAssignment(wt.path);
     onClose();
   };
 
   const handleWorktreeOpenedOrCreated = useCallback(
     async (wt: GitWorktree) => {
       setShowAddForm(false);
-      await createTerminal(wt.path);
+      await openTerminalWithPaneAssignment(wt.path);
       onClose();
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- openTerminalWithPaneAssignment only captures stable callbacks
     [createTerminal, onClose]
   );
 


### PR DESCRIPTION
## Summary
When creating or opening a worktree, the new terminal tab is now immediately placed into the focused pane layout instead of floating as a backgrounded tab. This fixes the issue where a newly created worktree tab would appear above all other tabs in the top-right panel, jumping to the correct group only after being clicked.

## Changes
- `src/components/WorktreeManager.tsx`: After creating a terminal for a worktree, now calls `assignTerminalToPane(focusedPaneId, newId)` to place it in the layout, matching the behavior of `handleNewTerminal` in `TerminalTabs.tsx`.

## Review Notes
- **Medium/Low**: Used `useTerminalLayoutStore.getState()` directly in handlers (Zustand pattern) rather than store subscription — intentional, matching the synchronous non-reactive nature of these click handlers.